### PR TITLE
Wheel refactor

### DIFF
--- a/FSAE.X/CAN.h
+++ b/FSAE.X/CAN.h
@@ -97,6 +97,7 @@
 #define FUEL_INJ_DUTY_BYTE  0
 #define FUEL_TRIM_BYTE      2
 #define SHIFT_FORCE_BYTE    4
+#define AIR_TEMP_BYTE       4
 
 // From GCM
 #define GEAR_BYTE           0
@@ -195,6 +196,7 @@
  */
 
 // From Diagnostic Message
+#define UPTIME_SCL          1
 #define PCB_TEMP_SCL        0.005
 #define IC_TEMP_SCL         0.005
 
@@ -244,6 +246,7 @@
 #define FUEL_INJ_DUTY_SCL   0.1
 #define FUEL_TRIM_SCL       0.1 //??
 #define SHIFT_FORCE_SCL     1.0 //??
+#define AIR_TEMP_SCL        1.0 //??
 
 // From GCM
 #define GEAR_SCL           1

--- a/FSAE.X/CAN.h
+++ b/FSAE.X/CAN.h
@@ -13,6 +13,7 @@
 #define ERROR_ID        0x00F
 #define ANALOG_REAR_ID  0x050
 #define ANALOG_FRONT_ID 0x060
+#define SPM_ID          0x050
 #define MOTEC_ID        0x100
 #define GCM_ID          0x200
 #define LOGGER_ID       0x300
@@ -191,6 +192,61 @@
 #define TIRE_TEMP_3_BYTE    4
 #define TIRE_TEMP_4_BYTE    6
 
+#define ANALOG_CHAN_0_BYTE    0
+#define ANALOG_CHAN_1_BYTE    2
+#define ANALOG_CHAN_2_BYTE    4
+#define ANALOG_CHAN_3_BYTE    6
+#define ANALOG_CHAN_4_BYTE    0
+#define ANALOG_CHAN_5_BYTE    2
+#define ANALOG_CHAN_6_BYTE    4
+#define ANALOG_CHAN_7_BYTE    6
+#define ANALOG_CHAN_8_BYTE    0
+#define ANALOG_CHAN_9_BYTE    2
+#define ANALOG_CHAN_10_BYTE   4
+#define ANALOG_CHAN_11_BYTE   6
+#define ANALOG_CHAN_12_BYTE   0
+#define ANALOG_CHAN_13_BYTE   2
+#define ANALOG_CHAN_14_BYTE   4
+#define ANALOG_CHAN_15_BYTE   6
+#define ANALOG_CHAN_16_BYTE   0
+#define ANALOG_CHAN_17_BYTE   2
+#define ANALOG_CHAN_18_BYTE   4
+#define ANALOG_CHAN_19_BYTE   6
+#define ANALOG_CHAN_20_BYTE   0
+#define ANALOG_CHAN_21_BYTE   2
+#define ANALOG_CHAN_22_BYTE   4
+#define ANALOG_CHAN_23_BYTE   6
+#define ANALOG_CHAN_24_BYTE   0
+#define ANALOG_CHAN_25_BYTE   2
+#define ANALOG_CHAN_26_BYTE   4
+#define ANALOG_CHAN_27_BYTE   6
+#define ANALOG_CHAN_28_BYTE   0
+#define ANALOG_CHAN_29_BYTE   2
+#define ANALOG_CHAN_30_BYTE   4
+#define ANALOG_CHAN_31_BYTE   6
+#define ANALOG_CHAN_32_BYTE   0
+#define ANALOG_CHAN_33_BYTE   2
+#define ANALOG_CHAN_34_BYTE   4
+#define ANALOG_CHAN_35_BYTE   6
+
+#define TCOUPLE_0_BYTE        0
+#define TCOUPLE_1_BYTE        2
+#define TCOUPLE_2_BYTE        4
+#define TCOUPLE_3_BYTE        6
+
+#define TCOUPLE_4_BYTE        0
+#define TCOUPLE_5_BYTE        2
+#define AVG_JUNCT_TEMP_BYTE   4
+#define TCOUPLE_FAULT_BYTE    6
+
+#define DIGITAL_INPUT_BYTE    0
+#define FREQ_COUNT_0_BYTE     2
+#define FREQ_COUNT_1_BYTE     4
+#define FREQ_COUNT_2_BYTE     6
+
+#define PGA_SETTINGS_BYTE     0
+#define FREQ_SETTINGS_BYTE    2
+
 /**
  * Scalars for channels
  */
@@ -257,10 +313,7 @@
 #define QUEUE_DN_SCL       1
 #define QUEUE_NT_SCL       1
 
-// From PDM
-#define PDM_UPTIME_SCL    1
-#define PDM_PCB_TEMP_SCL  0.005
-#define PDM_IC_TEMP_SCL   0.005
+// From PDM 
 #define TOTAL_CURRENT_SCL 0.01
 
 #define VOLT_RAIL_SCL     0.001
@@ -310,25 +363,152 @@
 // From Tire Temp Sensors
 #define TIRE_TEMP_SCL       0.1
 
+#define ANALOG_CHAN_0_SCL     0.001
+#define ANALOG_CHAN_1_SCL     0.001
+#define ANALOG_CHAN_2_SCL     0.001
+#define ANALOG_CHAN_3_SCL     0.001
+#define ANALOG_CHAN_4_SCL     0.001
+#define ANALOG_CHAN_5_SCL     0.001
+#define ANALOG_CHAN_6_SCL     0.001
+#define ANALOG_CHAN_7_SCL     0.001
+#define ANALOG_CHAN_8_SCL     0.001
+#define ANALOG_CHAN_9_SCL     0.001
+#define ANALOG_CHAN_10_SCL    0.001
+#define ANALOG_CHAN_11_SCL    0.001
+#define ANALOG_CHAN_12_SCL    0.001
+#define ANALOG_CHAN_13_SCL    0.001
+#define ANALOG_CHAN_14_SCL    0.001
+#define ANALOG_CHAN_15_SCL    0.001
+#define ANALOG_CHAN_16_SCL    0.001
+#define ANALOG_CHAN_17_SCL    0.001
+#define ANALOG_CHAN_18_SCL    0.001
+#define ANALOG_CHAN_19_SCL    0.001
+#define ANALOG_CHAN_20_SCL    0.001
+#define ANALOG_CHAN_21_SCL    0.001
+#define ANALOG_CHAN_22_SCL    0.001
+#define ANALOG_CHAN_23_SCL    0.001
+#define ANALOG_CHAN_24_SCL    0.001
+#define ANALOG_CHAN_25_SCL    0.001
+#define ANALOG_CHAN_26_SCL    0.001
+#define ANALOG_CHAN_27_SCL    0.001
+#define ANALOG_CHAN_28_SCL    0.001
+#define ANALOG_CHAN_29_SCL    0.001
+#define ANALOG_CHAN_30_SCL    0.001
+#define ANALOG_CHAN_31_SCL    0.001
+#define ANALOG_CHAN_32_SCL    0.001
+#define ANALOG_CHAN_33_SCL    0.001
+#define ANALOG_CHAN_34_SCL    0.001
+#define ANALOG_CHAN_35_SCL    0.001
+
+#define TCOUPLE_SCL         0.25
+
+#define TCOUPLE_4_SCL         0.25
+#define TCOUPLE_5_SCL         0.25
+#define AVG_JUNCT_TEMP_SCL    0.0625
+
+#define FREQ_COUNT_0_SCL      1 // ???
+#define FREQ_COUNT_1_SCL      1 // ???
+#define FREQ_COUNT_2_SCL      1 // ???
+
 /**
  * Masks for bitmaps & packed messages
  */
 
 // From Wheel
-#define FAN_OVER_MASK  0x10
-#define WTR_OVER_MASK  0x20
-#define FUEL_OVER_MASK 0x40
-#define RADIO_BTN_MASK 0x01
-#define ROT1_MASK      0xF0
-#define ROT2_MASK      0x0F
-#define ROT3_MASK      0xF0
+#define FAN_OVER_MASK         0x10
+#define WTR_OVER_MASK         0x20
+#define FUEL_OVER_MASK        0x40
+#define RADIO_BTN_MASK        0x01
+#define ROT1_MASK             0xF0
+#define ROT2_MASK             0x0F
+#define ROT3_MASK             0xF0
 
-// From PDM
-#define KILL_SW_MASK   0x08
-#define ACT_DN_SW_MASK 0x10
-#define ACT_UP_SW_MASK 0x20
-#define ON_SW_MASK     0x40
-#define STR_SW_MASK    0x80
+//PDM Bitmask bits
+#define STR_ENBL_MASK         0x10
+#define BVBAT_ENBL_MASK       0x20
+#define AUX_ENBL_MASK         0x40
+#define ECU_ENBL_MASK         0x80
+#define WTR_ENBL_MASK         0x100
+#define FAN_ENBL_MASK         0x200
+#define PDLD_ENBL_MASK        0x400
+#define PDLU_ENBL_MASK        0x800
+#define ABS_ENBL_MASK         0x1000
+#define INJ_ENBL_MASK         0x2000
+#define IGN_ENBL_MASK         0x4000
+#define FUEL_ENBL_MASK        0x8000
+
+#define STR_PEAKM_MASK        0x10
+#define BVBAT_PEAKM_MASK      0x20
+#define AUX_PEAKM_MASK        0x40
+#define ECU_PEAKM_MASK        0x80
+#define WTR_PEAKM_MASK        0x100
+#define FAN_PEAKM_MASK        0x200
+#define PDLD_PEAKM_MASK       0x400
+#define PDLU_PEAKM_MASK       0x800
+#define ABS_PEAKM_MASK        0x1000
+#define INJ_PEAKM_MASK        0x2000
+#define IGN_PEAKM_MASK        0x4000
+#define FUEL_PEAKM_MASK       0x8000
+
+#define AUX2_PDM_SW_MASK      0x1
+#define AUX1_PDM_SW_MASK      0x2
+#define ABS_PDM_SW_MASK       0x4
+#define KILL_PDM_SW_MASK      0x8
+#define ACT_DN_PDM_SW_MASK    0x10
+#define ACT_UP_PDM_SW_MASK    0x20
+#define ON_PDM_SW_MASK        0x40
+#define STR_PDM_SW_MASK       0x80
+
+#define KILL_ENGINE_PDM_FLAG_MASK   0x10
+#define KILL_CAR_PDM_FLAG_MASK      0x20
+#define OVER_TEMP_PDM_FLAG_MASK     0x40
+#define FUEL_PRIME_PDM_FLAG_MASK    0x80
+
+#define PADDLE_UP_GCM_SW_MASK       0x1
+#define PADDLE_DOWN_GCM_SW_MASK     0x2
+#define NEUTRAL_GCM_SW_MASK         0x4
+
+//SPM Bitmasks
+#define TCOUPLE_0_FAULT_MASK        0x1
+#define TCOUPLE_1_FAULT_MASK        0x2
+#define TCOUPLE_2_FAULT_MASK        0x4
+#define TCOUPLE_3_FAULT_MASK        0x8
+#define TCOUPLE_4_FAULT_MASK        0x10
+#define TCOUPLE_5_FAULT_MASK        0x20
+
+#define DIGITAL_INPUT_0_MASK        0x1
+#define DIGITAL_INPUT_1_MASK        0x2
+#define DIGITAL_INPUT_2_MASK        0x4
+#define DIGITAL_INPUT_3_MASK        0x8
+#define DIGITAL_INPUT_4_MASK        0x10
+#define DIGITAL_INPUT_5_MASK        0x20
+#define DIGITAL_INPUT_6_MASK        0x40
+#define DIGITAL_INPUT_7_MASK        0x80
+#define DIGITAL_INPUT_8_MASK        0x100
+#define DIGITAL_INPUT_9_MASK        0x200
+#define DIGITAL_INPUT_10_MASK       0x400
+#define DIGITAL_INPUT_11_MASK       0x800
+#define DIGITAL_INPUT_12_MASK       0x1000
+#define DIGITAL_INPUT_13_MASK       0x2000
+#define DIGITAL_INPUT_14_MASK       0x4000
+#define DIGITAL_INPUT_15_MASK       0x8000
+
+#define PGA_0_SETTINGS_MASK         0x7
+#define PGA_1_SETTINGS_MASK         0x38
+#define PGA_2_SETTINGS_MASK         0x1C0
+#define PGA_3_SETTINGS_MASK         0xE00
+#define FREQ_0_SETTINGS_MASK        0x1F
+#define FREQ_1_SETTINGS_MASK        0x3E0
+#define FREQ_2_SETTINGS_MASK        0x7C00
+
+#define PGA_0_SETTINGS_SHF          0
+#define PGA_1_SETTINGS_SHF          3
+#define PGA_2_SETTINGS_SHF          6
+#define PGA_3_SETTINGS_SHF          9
+#define FREQ_0_SETTINGS_SHF         0
+#define FREQ_1_SETTINGS_SHF         5
+#define FREQ_2_SETTINGS_SHF         10
+
 
 /**
  * ADL definitions

--- a/Wheel_Node.X/FSAE_LCD.c
+++ b/Wheel_Node.X/FSAE_LCD.c
@@ -98,10 +98,8 @@ void initDataItems(void){
   initDataItem(&accelPedalPos1,0,0,MIN_REFRESH,2,1);
   // Uptimes
   // uptimes - 4,0
-  initDataItem(&paddleUptime,0,0,MIN_REFRESH,2,1);
   initDataItem(&loggerUptime,0,0,MIN_REFRESH,2,1);
   initDataItem(&swUptime,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmUptime,0,0,MIN_REFRESH,2,1);
   initDataItem(&brakeMinFront,0,0,MIN_REFRESH,2,1);
   initDataItem(&brakeMaxFront,0,0,MIN_REFRESH,2,1);
   initDataItem(&brakeMinRear,0,0,MIN_REFRESH,2,1);

--- a/Wheel_Node.X/FSAE_LCD.c
+++ b/Wheel_Node.X/FSAE_LCD.c
@@ -13,6 +13,15 @@
 // Initialize all the data streams
 // This fn must be run before CAN is initialized
 void initDataItems(void){
+  int i;
+
+  // Set default initialization for PDM data items
+  for(i=0;i<PDM_DATAITEM_SIZE;i++){
+    initDataItem(&(pdmDataItems[i]),0,0,MIN_REFRESH,2,1);
+  }
+
+  pdmDataItems[STR_DRAW_IDX].wholeDigits = 3;
+
   // Motec Vars
   // Refresh Intervals
   // All Temp Channels - 500
@@ -80,73 +89,6 @@ void initDataItems(void){
   initDataItem(&downQueue,0,0,MIN_REFRESH,1,0);
   initDataItem(&gearVoltage,0,0,MIN_REFRESH,1,2);
 
-  // PDM
-  initDataItem(&pdmTemp,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmICTemp,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmCurrentDraw,0,0,MIN_REFRESH,3,1);
-  initDataItem(&pdmVBat,0,0,MIN_REFRESH,2,2);
-  initDataItem(&pdm12v,0,0,MIN_REFRESH,2,2);
-  initDataItem(&pdm5v5,0,0,MIN_REFRESH,1,2);
-  initDataItem(&pdm5v,0,0,MIN_REFRESH,1,2);
-  initDataItem(&pdm3v3,0,0,MIN_REFRESH,1,2);
-  // Draw (^str) - 2,2
-  // Cut (^str)) - 3,1
-  initDataItem(&pdmIGNdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmIGNcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmINJdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmINJcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmFUELdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmFUELcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmFUELPcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmECUdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmECUcut,0,0,MIN_REFRESH,0,1);
-  initDataItem(&pdmECUPcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmWTRdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmWTRcut,0,0,MIN_REFRESH,0,1);
-  initDataItem(&pdmWTRPcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmFANdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmFANcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmFANPcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmAUXdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmAUXcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmPDLUdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmPDLUcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmPDLDdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmPDLDcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdm5v5cut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmBATdraw,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmBATcut,0,0,MIN_REFRESH,2,1);
-  initDataItem(&pdmSTRdraw,0,0,MIN_REFRESH,3,1);
-  initDataItem(&pdmSTRcut,0,0,MIN_REFRESH,2,1);
-
-  // PDM Bitmaps
-  initDataItem(&STRenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&BVBATenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&PDLDenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&PDLUenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&AUXenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&FANenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&WTRenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&ECUenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&FUELenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&INJenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&IGNenabl,0,0,MIN_REFRESH,1,0);
-  initDataItem(&BVBATpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&PDLDpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&PDLUpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&AUXpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&FANpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&WTRpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&ECUpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&FUELpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&INJpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&IGNpm,0,0,MIN_REFRESH,1,0);
-  initDataItem(&KILLpdmSw,0,0,MIN_REFRESH,1,0);
-  initDataItem(&ACT_DNpdmSw,0,0,MIN_REFRESH,1,0);
-  initDataItem(&ACT_UPpdmSw,0,0,MIN_REFRESH,1,0);
-  initDataItem(&ONpdmSw,0,0,MIN_REFRESH,1,0);
-  initDataItem(&STRpdmSw,0,0,MIN_REFRESH,1,0);
-
   // Rear Analog Hub
   initDataItem(&susPosRR,0,0,MIN_REFRESH,2,1);
   initDataItem(&susPosRL,0,0,MIN_REFRESH,2,1);
@@ -206,11 +148,11 @@ void initDataItems(void){
   initDataItem(&momentaries[3],0,0,MIN_REFRESH,1,0);
 
   fanSw[0] = &switches[0];
-  fanSw[1] = &FANenabl;
+  fanSw[1] = &pdmDataItems[FAN_ENABLITY_IDX];
   fuelSw[0] = &switches[1];
-  fuelSw[1] = &FUELenabl;
+  fuelSw[1] = &pdmDataItems[FUEL_ENABLITY_IDX];
   wtrSw[0] = &switches[2];
-  wtrSw[1] = &WTRenabl;
+  wtrSw[1] = &pdmDataItems[WTR_ENABLITY_IDX];
 }
 
 void initDataItem(volatile dataItem* data, double warn, double err, uint32_t refresh, uint8_t whole, uint8_t dec){
@@ -258,59 +200,58 @@ void initAllScreens(void){
   initScreenItem(&raceScreenItems[6], 330, 180, 30, redrawDigit, &batVoltage);
   initScreenItem(&raceScreenItems[7], 170, 50, 100, redrawGearPos, &gearPos);
   initScreenItem(&raceScreenItems[8], 20, 30, 15, redrawShiftLightsRPM, &rpm);
-  initScreenItem(&raceScreenItems[9], 20, 30, 15, redrawKILLCluster, &KILLpdmSw);
+  initScreenItem(&raceScreenItems[9], 20, 30, 15, redrawKILLCluster, &pdmDataItems[KILL_SWITCH_IDX]);
 
   // PDM stuff
   allScreens[PDM_DRAW_SCREEN] = &pdmDrawScreen;
   pdmDrawScreen.items = pdmDrawItems;
   pdmDrawScreen.len = 20;
-  initScreenItem(&pdmDrawItems[1], 10, 50, 15, redrawDigit, &pdmIGNdraw);
-  initScreenItem(&pdmDrawItems[2], 85, 50, 15, redrawDigit, &pdmINJdraw);
-  initScreenItem(&pdmDrawItems[3], 160, 50, 15, redrawDigit, &pdmFUELdraw);
-  initScreenItem(&pdmDrawItems[4], 235, 50, 15, redrawDigit, &pdmECUdraw);
-  initScreenItem(&pdmDrawItems[5], 310, 50, 15, redrawDigit, &pdmWTRdraw);
-  initScreenItem(&pdmDrawItems[6], 385, 50, 15, redrawDigit, &pdmFANdraw);
-  initScreenItem(&pdmDrawItems[7], 10, 100, 15, redrawDigit, &pdmAUXdraw);
-  initScreenItem(&pdmDrawItems[8], 85, 100, 15, redrawDigit, &pdmPDLUdraw);
-  initScreenItem(&pdmDrawItems[9], 160, 100, 15, redrawDigit, &pdmPDLDdraw);
-  initScreenItem(&pdmDrawItems[10], 235, 100, 15, redrawDigit, &pdm5v5draw);
-  initScreenItem(&pdmDrawItems[11], 310, 100, 15, redrawDigit, &pdmBATdraw);
-  initScreenItem(&pdmDrawItems[16], 385, 100, 15, redrawDigit, &pdmFUELPcut);
-  initScreenItem(&pdmDrawItems[17], 10, 150, 15, redrawDigit, &pdmECUPcut);
-  initScreenItem(&pdmDrawItems[18], 85, 150, 15, redrawDigit, &pdmWTRPcut);
-  initScreenItem(&pdmDrawItems[19], 160, 150, 15, redrawDigit, &pdmFANPcut);
-  initScreenItem(&pdmDrawItems[15], 280, 200, 15, redrawDigit, &pdmSTRdraw);
-  initScreenItem(&pdmDrawItems[0], 370, 200, 15, redrawDigit, &pdmCurrentDraw);
+  initScreenItem(&pdmDrawItems[1], 10, 50, 15, redrawDigit, &pdmDataItems[IGN_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[2], 85, 50, 15, redrawDigit, &pdmDataItems[INJ_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[3], 160, 50, 15, redrawDigit, &pdmDataItems[FUEL_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[4], 235, 50, 15, redrawDigit, &pdmDataItems[ECU_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[5], 310, 50, 15, redrawDigit, &pdmDataItems[WTR_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[6], 385, 50, 15, redrawDigit, &pdmDataItems[FAN_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[7], 10, 100, 15, redrawDigit, &pdmDataItems[AUX_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[8], 85, 100, 15, redrawDigit, &pdmDataItems[PDLU_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[9], 160, 100, 15, redrawDigit, &pdmDataItems[PDLD_DRAW_IDX]);
+  //changed from 5v5
+  initScreenItem(&pdmDrawItems[10], 235, 100, 15, redrawDigit, &pdmDataItems[ABS_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[11], 310, 100, 15, redrawDigit, &pdmDataItems[BVBAT_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[16], 385, 100, 15, redrawDigit, &pdmDataItems[FUEL_CUT_P_IDX]);
+  initScreenItem(&pdmDrawItems[17], 10, 150, 15, redrawDigit, &pdmDataItems[ECU_CUT_P_IDX]);
+  initScreenItem(&pdmDrawItems[18], 85, 150, 15, redrawDigit, &pdmDataItems[WTR_CUT_P_IDX]);
+  initScreenItem(&pdmDrawItems[19], 160, 150, 15, redrawDigit, &pdmDataItems[FAN_CUT_P_IDX]);
+  initScreenItem(&pdmDrawItems[15], 280, 200, 15, redrawDigit, &pdmDataItems[STR_DRAW_IDX]);
+  initScreenItem(&pdmDrawItems[0], 370, 200, 15, redrawDigit, &pdmDataItems[TOTAL_CURRENT_IDX]);
 
 
   allScreens[PDM_CUT_SCREEN] = &pdmCutScreen;
   pdmCutScreen.items = pdmCutItems;
   pdmCutScreen.len = 21;
-  initScreenItem(&pdmCutItems[0], 10, 50, 15, redrawDigit, &pdmTemp);
-  initScreenItem(&pdmCutItems[1], 85, 50, 15, redrawDigit, &pdmICTemp);
-  initScreenItem(&pdmCutItems[4], 310, 50, 15, redrawDigit, &pdm5v5);
-  initScreenItem(&pdmCutItems[5], 385, 50, 15, redrawDigit, &pdm5v);
-  initScreenItem(&pdmCutItems[6], 10, 100, 15, redrawDigit, &pdm3v3);
-  initScreenItem(&pdmCutItems[7], 85, 100, 15, redrawDigit, &pdmIGNcut);
-  initScreenItem(&pdmCutItems[8], 160, 100, 15, redrawDigit, &pdmINJcut);
-  initScreenItem(&pdmCutItems[9], 235, 100, 15, redrawDigit, &pdmFUELcut);
-  pdmECUcut.decDigits = 1;
-  pdmECUcut.wholeDigits = 2;
-  initScreenItem(&pdmCutItems[10], 160, 50, 15, redrawDigit, &pdmECUcut);
-  initScreenItem(&pdmCutItems[12], 10, 150, 15, redrawDigit, &pdmFANcut);
-  initScreenItem(&pdmCutItems[13], 85, 150, 15, redrawDigit, &pdmAUXcut);
-  initScreenItem(&pdmCutItems[14], 160, 150, 15, redrawDigit, &pdmPDLUcut);
-  initScreenItem(&pdmCutItems[15], 235, 150, 15, redrawDigit, &pdmPDLDcut);
-  initScreenItem(&pdmCutItems[16], 310, 150, 15, redrawDigit, &pdm5v5cut);
-  initScreenItem(&pdmCutItems[17], 385, 150, 15, redrawDigit, &pdmBATcut);
-  initScreenItem(&pdmCutItems[18], 10, 200, 15, redrawDigit, &pdmSTRcut);
+  initScreenItem(&pdmCutItems[0], 10, 50, 15, redrawDigit, &pdmDataItems[PCB_TEMP_IDX]);
+  initScreenItem(&pdmCutItems[1], 85, 50, 15, redrawDigit, &pdmDataItems[IC_TEMP_IDX]);
+  initScreenItem(&pdmCutItems[4], 310, 50, 15, redrawDigit, 0x0);
+  initScreenItem(&pdmCutItems[5], 385, 50, 15, redrawDigit, 0x0);
+  initScreenItem(&pdmCutItems[6], 10, 100, 15, redrawDigit, 0x0);
+  initScreenItem(&pdmCutItems[7], 85, 100, 15, redrawDigit, &pdmDataItems[IGN_CUT_IDX]);
+  initScreenItem(&pdmCutItems[8], 160, 100, 15, redrawDigit, &pdmDataItems[INJ_CUT_IDX]);
+  initScreenItem(&pdmCutItems[9], 235, 100, 15, redrawDigit, &pdmDataItems[FUEL_CUT_IDX]);
+  initScreenItem(&pdmCutItems[10], 160, 50, 15, redrawDigit,  &pdmDataItems[ECU_CUT_IDX]);
+  initScreenItem(&pdmCutItems[12], 10, 150, 15, redrawDigit,  &pdmDataItems[FAN_CUT_IDX]);
+  initScreenItem(&pdmCutItems[13], 85, 150, 15, redrawDigit,  &pdmDataItems[AUX_CUT_IDX]);
+  initScreenItem(&pdmCutItems[14], 160, 150, 15, redrawDigit, &pdmDataItems[PDLU_CUT_IDX]);
+  initScreenItem(&pdmCutItems[15], 235, 150, 15, redrawDigit, &pdmDataItems[PDLD_CUT_IDX]);
+  initScreenItem(&pdmCutItems[16], 310, 150, 15, redrawDigit, &pdmDataItems[ABS_CUT_IDX]);
+  initScreenItem(&pdmCutItems[17], 385, 150, 15, redrawDigit, &pdmDataItems[BVBAT_CUT_IDX]);
+  initScreenItem(&pdmCutItems[18], 10, 200, 15, redrawDigit,  0x0);
 
   //brake pressure
   initScreenItem(&pdmCutItems[19], 85, 200, 15, redrawDigit,&brakePressFront);
   initScreenItem(&pdmCutItems[20], 160, 200, 15, redrawDigit, &brakePressRear);
 
-  initScreenItem(&pdmCutItems[2], 235, 200, 15, redrawDigit, &pdmVBat);
-  initScreenItem(&pdmCutItems[3], 330, 200, 15, redrawDigit, &pdm12v);
+  initScreenItem(&pdmCutItems[2], 235, 200, 15, redrawDigit, &pdmDataItems[VBAT_RAIL_IDX]);
+  initScreenItem(&pdmCutItems[3], 330, 200, 15, redrawDigit, &pdmDataItems[V12_RAIL_IDX]);
 
 
   // MoTec Stuff

--- a/Wheel_Node.X/FSAE_LCD.c
+++ b/Wheel_Node.X/FSAE_LCD.c
@@ -20,7 +20,21 @@ void initDataItems(void){
     initDataItem(&(pdmDataItems[i]),0,0,MIN_REFRESH,2,1);
   }
 
+  // Customized PDM dataitem initialization
   pdmDataItems[STR_DRAW_IDX].wholeDigits = 3;
+
+  // Set default initialization for GCM data items
+  for(i=0;i<GCM_DATAITEM_SIZE;i++){
+    initDataItem(&(gcmDataItems[i]),0,0,MIN_REFRESH,1,0);
+  }
+
+  // Customized GCM dataitem initialization
+  gcmDataItems[GEAR_VOLT_IDX].decDigits = 2;
+  gcmDataItems[GEAR_VOLT_IDX].wholeDigits = 2;
+  gcmDataItems[FORCE_IDX].decDigits = 2;
+  gcmDataItems[FORCE_IDX].wholeDigits = 2;
+
+
 
   // Motec Vars
   // Refresh Intervals
@@ -80,14 +94,6 @@ void initDataItems(void){
   initDataItem(&ttRRA[2],0,0,MIN_REFRESH,2,1);
   initDataItem(&ttRRA[3],0,0,MIN_REFRESH,2,1);
   initDataItem(&ttRR,0,0,MIN_REFRESH,2,1);
-
-  // Paddle Shifting
-  initDataItem(&paddleTemp,0,0,MIN_REFRESH,2,1);
-  initDataItem(&gearPos,0,0,MIN_REFRESH,1,0);
-  initDataItem(&neutQueue,0,0,MIN_REFRESH,1,0);
-  initDataItem(&upQueue,0,0,MIN_REFRESH,1,0);
-  initDataItem(&downQueue,0,0,MIN_REFRESH,1,0);
-  initDataItem(&gearVoltage,0,0,MIN_REFRESH,1,2);
 
   // Rear Analog Hub
   initDataItem(&susPosRR,0,0,MIN_REFRESH,2,1);
@@ -198,7 +204,7 @@ void initAllScreens(void){
   initScreenItem(&raceScreenItems[4], 330, 70, 30, redrawDigit, &waterTemp);
   initScreenItem(&raceScreenItems[5], 20, 190, 30, redrawDigit, &oilPress);
   initScreenItem(&raceScreenItems[6], 330, 180, 30, redrawDigit, &batVoltage);
-  initScreenItem(&raceScreenItems[7], 170, 50, 100, redrawGearPos, &gearPos);
+  initScreenItem(&raceScreenItems[7], 170, 50, 100, redrawGearPos, &gcmDataItems[GEAR_IDX]);
   initScreenItem(&raceScreenItems[8], 20, 30, 15, redrawShiftLightsRPM, &rpm);
   initScreenItem(&raceScreenItems[9], 20, 30, 15, redrawKILLCluster, &pdmDataItems[KILL_SWITCH_IDX]);
 

--- a/Wheel_Node.X/FSAE_LCD.c
+++ b/Wheel_Node.X/FSAE_LCD.c
@@ -61,6 +61,10 @@ void initDataItems(void){
     initDataItem(&tireTempDataItems[i],0,0,MIN_REFRESH,2,1); 
   }
 
+  for(i=0;i<SPM_DATAITEM_SIZE;i++) {
+    initDataItem(&spmDataItems[i],0,0,MIN_REFRESH,2,1);
+  }
+
   // Rear Analog Hub
   initDataItem(&susPosRR,0,0,MIN_REFRESH,2,1);
   initDataItem(&susPosRL,0,0,MIN_REFRESH,2,1);

--- a/Wheel_Node.X/FSAE_LCD.c
+++ b/Wheel_Node.X/FSAE_LCD.c
@@ -56,27 +56,10 @@ void initDataItems(void){
   setDataItemDigits(&motecDataItems[FUEL_INJ_DUTY_IDX], 3, 1);
   setDataItemDigits(&motecDataItems[FUEL_TRIM_IDX], 3, 1);
 
-  // Tire Temps
-  initDataItem(&ttFLA[0],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFLA[1],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFLA[2],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFLA[3],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFL,0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFRA[0],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFRA[1],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFRA[2],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFRA[3],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttFR,0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRLA[0],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRLA[1],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRLA[2],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRLA[3],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRL,0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRRA[0],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRRA[1],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRRA[2],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRRA[3],0,0,MIN_REFRESH,2,1);
-  initDataItem(&ttRR,0,0,MIN_REFRESH,2,1);
+  // Tire temps
+  for(i=0;i<TIRETEMP_DATAITEM_SIZE;i++) {
+    initDataItem(&tireTempDataItems[i],0,0,MIN_REFRESH,2,1); 
+  }
 
   // Rear Analog Hub
   initDataItem(&susPosRR,0,0,MIN_REFRESH,2,1);
@@ -263,18 +246,6 @@ void initAllScreens(void){
   initScreenItem(&endRaceItems[6], 10, 30, 20, redrawTireTemp, &endTireTempRR);
   initScreenItem(&endRaceItems[7], 10, 30, 20, redrawDigit, &endAmbientTemp);
   initScreenItem(&endRaceItems[8], 10, 30, 20, redrawDigit, &endFuelConsum);
-
-  allScreens[CHASSIS_SCREEN] = &chassisScreen;
-  chassisScreen.items = chassisItems;
-  chassisScreen.len = 20;
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawDigit, &ttFL);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawDigit, &ttFR);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawDigit, &ttRL);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawDigit, &ttRR);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawTireTemp, ttFLA);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawTireTemp, ttFRA);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawTireTemp, ttRLA);
-  initScreenItem(&chassisItems[0], 10, 30, 20, redrawTireTemp, ttRRA);
 
   //brake screen
   allScreens[BRAKE_SCREEN] = &brakeScreen;
@@ -792,10 +763,10 @@ void endRace(void){
   endLogNum.value = 0;
   endNumLaps.value = numLaps;
   endFastLap.value = getMinLap();
-  endTireTempFL.value = ttFL.value;
-  endTireTempFR.value = ttFR.value;
-  endTireTempRL.value = ttRL.value;
-  endTireTempRR.value = ttRR.value;
+  endTireTempFL.value = tireTempDataItems[FL].value;
+  endTireTempFR.value = tireTempDataItems[FR].value;
+  endTireTempRL.value = tireTempDataItems[RL].value;
+  endTireTempRR.value = tireTempDataItems[RR].value;
   endAmbientTemp.value = motecDataItems[AIR_TEMP_IDX].value;
   endFuelConsum.value = motecDataItems[FUEL_USED_IDX].value;
 }

--- a/Wheel_Node.X/FSAE_LCD.c
+++ b/Wheel_Node.X/FSAE_LCD.c
@@ -17,7 +17,7 @@ void initDataItems(void){
 
   // Set default initialization for PDM data items
   for(i=0;i<PDM_DATAITEM_SIZE;i++){
-    initDataItem(&(pdmDataItems[i]),0,0,MIN_REFRESH,2,1);
+    initDataItem(&pdmDataItems[i],0,0,MIN_REFRESH,2,1);
   }
 
   // Customized PDM dataitem initialization
@@ -25,7 +25,7 @@ void initDataItems(void){
 
   // Set default initialization for GCM data items
   for(i=0;i<GCM_DATAITEM_SIZE;i++){
-    initDataItem(&(gcmDataItems[i]),0,0,MIN_REFRESH,1,0);
+    initDataItem(&gcmDataItems[i],0,0,MIN_REFRESH,1,0);
   }
 
   // Customized GCM dataitem initialization
@@ -34,44 +34,27 @@ void initDataItems(void){
   gcmDataItems[FORCE_IDX].decDigits = 2;
   gcmDataItems[FORCE_IDX].wholeDigits = 2;
 
+  // Set default initializations for Motec data items
+  for(i=0;i<MOTEC_DATAITEM_SIZE;i++) {
+    initDataItem(&motecDataItems[i],0,0,MIN_REFRESH,2,1);
+  }
 
-
-  // Motec Vars
-  // Refresh Intervals
-  // All Temp Channels - 500
-  initDataItem(&rpm,0,0,MIN_REFRESH,5,0);
-  initDataItem(&throtPos,0,0,MIN_REFRESH,3,1);
-  initDataItem(&oilPress,0,0,MIN_REFRESH,1,2);
-  initDataItem(&oilTemp,0,0,MIN_REFRESH,3,0);
-  initDataItem(&waterTemp,0,0,MIN_REFRESH,3,0);
-  initDataItem(&lambda,0,0,MIN_REFRESH,1,3);
-  initDataItem(&manifoldPress,0,0,MIN_REFRESH,1,2);
-  initDataItem(&batVoltage,0,0,MIN_REFRESH,2,2);
-  initDataItem(&wheelSpeedFL,0,0,MIN_REFRESH,2,1);
-  initDataItem(&wheelSpeedFR,0,0,MIN_REFRESH,2,1);
-  initDataItem(&wheelSpeedRL,0,0,MIN_REFRESH,2,1);
-  initDataItem(&wheelSpeedRR,0,0,MIN_REFRESH,2,1);
-  initDataItem(&gpsLong,0,0,MIN_REFRESH,2,1); // Don't need
-  initDataItem(&gpsLat,0,0,MIN_REFRESH,2,1); // Don't need
-  initDataItem(&groundSpeed,0,0,MIN_REFRESH,2,1);
-  initDataItem(&driveSpeed,0,0,MIN_REFRESH,2,1);
-  initDataItem(&gpsSpeed,0,0,MIN_REFRESH,2,1);
-  initDataItem(&manifoldTemp,0,0,MIN_REFRESH,3,0);
-  initDataItem(&ambientTemp,0,0,MIN_REFRESH,3,0);
-  initDataItem(&ambientPress,0,0,MIN_REFRESH,1,2);
-  initDataItem(&fuelTemp,0,0,MIN_REFRESH,3,0);
-  initDataItem(&fuelPress,0,0,MIN_REFRESH,1,2);
-  initDataItem(&lambda1,0,0,MIN_REFRESH,1,3);
-  initDataItem(&lambda2,0,0,MIN_REFRESH,1,3);
-  initDataItem(&lambda3,0,0,MIN_REFRESH,1,3);
-  initDataItem(&lambda4,0,0,MIN_REFRESH,1,3);
-  initDataItem(&lcEnablity,0,0,MIN_REFRESH,1,0);
-  initDataItem(&fuelConsum,0,0,MIN_REFRESH,2,1);
-  initDataItem(&gpsAltitude,0,0,MIN_REFRESH,2,1); // ?
-  initDataItem(&gpsTime,0,0,MIN_REFRESH,2,1); // ?
-  initDataItem(&runTime,0,0,MIN_REFRESH,4,0);
-  initDataItem(&fuelInjDuty,0,0,MIN_REFRESH,3,1);
-  initDataItem(&fuelTrim,0,0,MIN_REFRESH,3,1);
+  // Customized Motec dataitem initialization
+  setDataItemDigits(&motecDataItems[ENG_RPM_IDX], 5, 0);
+  setDataItemDigits(&motecDataItems[THROTTLE_POS_IDX], 0, 2);
+  setDataItemDigits(&motecDataItems[OIL_PRES_IDX], 1, 2);
+  setDataItemDigits(&motecDataItems[OIL_TEMP_IDX], 3, 0);
+  setDataItemDigits(&motecDataItems[LAMBDA_IDX], 3, 1);
+  setDataItemDigits(&motecDataItems[MANIFOLD_PRES_IDX], 1, 2);
+  setDataItemDigits(&motecDataItems[MANIFOLD_TEMP_IDX], 3, 0);
+  setDataItemDigits(&motecDataItems[ENG_TEMP_IDX], 3, 0);
+  setDataItemDigits(&motecDataItems[VOLT_ECU_IDX], 2, 2);
+  setDataItemDigits(&motecDataItems[AMBIENT_PRES_IDX], 1, 2);
+  setDataItemDigits(&motecDataItems[FUEL_PRES_IDX], 1, 2);
+  setDataItemDigits(&motecDataItems[FUEL_TEMP_IDX], 3, 0);
+  setDataItemDigits(&motecDataItems[RUN_TIME_IDX], 4, 0);
+  setDataItemDigits(&motecDataItems[FUEL_INJ_DUTY_IDX], 3, 1);
+  setDataItemDigits(&motecDataItems[FUEL_TRIM_IDX], 3, 1);
 
   // Tire Temps
   initDataItem(&ttFLA[0],0,0,MIN_REFRESH,2,1);
@@ -170,6 +153,11 @@ void initDataItem(volatile dataItem* data, double warn, double err, uint32_t ref
   data->decDigits = dec;
 }
 
+void setDataItemDigits(volatile dataItem* data, uint8_t whole, uint8_t dec) {
+  data->wholeDigits = whole;
+  data->decDigits = dec;
+}
+
 // Initializes all the screen and screenitem variables in all
 // the screens that might be displayed
 void initAllScreens(void){
@@ -200,12 +188,12 @@ void initAllScreens(void){
   initScreenItem(&raceScreenItems[0], 120, 20, 15, redrawFanSw, *fanSw);
   initScreenItem(&raceScreenItems[1], 240, 20, 15, redrawFUELPumpSw,*fuelSw);
   initScreenItem(&raceScreenItems[2], 360, 20, 15, redrawWTRPumpSw, *wtrSw);
-  initScreenItem(&raceScreenItems[3], 20, 70, 30, redrawDigit, &oilTemp);
-  initScreenItem(&raceScreenItems[4], 330, 70, 30, redrawDigit, &waterTemp);
-  initScreenItem(&raceScreenItems[5], 20, 190, 30, redrawDigit, &oilPress);
-  initScreenItem(&raceScreenItems[6], 330, 180, 30, redrawDigit, &batVoltage);
+  initScreenItem(&raceScreenItems[3], 20, 70, 30, redrawDigit, &motecDataItems[OIL_TEMP_IDX]);
+  initScreenItem(&raceScreenItems[4], 330, 70, 30, redrawDigit, &motecDataItems[ENG_TEMP_IDX]);
+  initScreenItem(&raceScreenItems[5], 20, 190, 30, redrawDigit, &motecDataItems[OIL_PRES_IDX]);
+  initScreenItem(&raceScreenItems[6], 330, 180, 30, redrawDigit, &pdmDataItems[VBAT_RAIL_IDX]);
   initScreenItem(&raceScreenItems[7], 170, 50, 100, redrawGearPos, &gcmDataItems[GEAR_IDX]);
-  initScreenItem(&raceScreenItems[8], 20, 30, 15, redrawShiftLightsRPM, &rpm);
+  initScreenItem(&raceScreenItems[8], 20, 30, 15, redrawShiftLightsRPM, &motecDataItems[ENG_RPM_IDX]);
   initScreenItem(&raceScreenItems[9], 20, 30, 15, redrawKILLCluster, &pdmDataItems[KILL_SWITCH_IDX]);
 
   // PDM stuff
@@ -259,43 +247,6 @@ void initAllScreens(void){
   initScreenItem(&pdmCutItems[2], 235, 200, 15, redrawDigit, &pdmDataItems[VBAT_RAIL_IDX]);
   initScreenItem(&pdmCutItems[3], 330, 200, 15, redrawDigit, &pdmDataItems[V12_RAIL_IDX]);
 
-
-  // MoTec Stuff
-  allScreens[MOTEC_SCREEN] = &motecScreen;
-  motecScreen.items = motecItems;
-  motecScreen.len = 30;
-  initScreenItem(&motecItems[0], 10, 30, 20, redrawDigit, &rpm);
-  initScreenItem(&motecItems[1], 10, 30, 20, redrawDigit, &throtPos);
-  initScreenItem(&motecItems[2], 10, 30, 20, redrawDigit, &oilPress);
-  initScreenItem(&motecItems[3], 10, 30, 20, redrawDigit, &oilTemp);
-  initScreenItem(&motecItems[4], 10, 30, 20, redrawDigit, &waterTemp);
-  initScreenItem(&motecItems[5], 10, 30, 20, redrawDigit, &lambda);
-  initScreenItem(&motecItems[6], 10, 30, 20, redrawDigit, &manifoldPress);
-  initScreenItem(&motecItems[7], 10, 30, 20, redrawDigit, &batVoltage);
-  initScreenItem(&motecItems[8], 10, 30, 20, redrawDigit, &wheelSpeedFL);
-  initScreenItem(&motecItems[9], 10, 30, 20, redrawDigit, &wheelSpeedFR);
-  initScreenItem(&motecItems[10], 10, 30, 20, redrawDigit, &wheelSpeedRL);
-  initScreenItem(&motecItems[11], 10, 30, 20, redrawDigit, &wheelSpeedRR);
-  initScreenItem(&motecItems[12], 10, 30, 20, redrawDigit, &gpsLat);
-  initScreenItem(&motecItems[13], 10, 30, 20, redrawDigit, &gpsLong);
-  initScreenItem(&motecItems[14], 10, 30, 20, redrawDigit, &groundSpeed);
-  initScreenItem(&motecItems[15], 10, 30, 20, redrawDigit, &driveSpeed);
-  initScreenItem(&motecItems[16], 10, 30, 20, redrawDigit, &gpsSpeed);
-  initScreenItem(&motecItems[17], 10, 30, 20, redrawDigit, &manifoldTemp);
-  initScreenItem(&motecItems[18], 10, 30, 20, redrawDigit, &ambientTemp);
-  initScreenItem(&motecItems[19], 10, 30, 20, redrawDigit, &ambientPress);
-  initScreenItem(&motecItems[20], 10, 30, 20, redrawDigit, &fuelTemp);
-  initScreenItem(&motecItems[21], 10, 30, 20, redrawDigit, &fuelPress);
-  initScreenItem(&motecItems[22], 10, 30, 20, redrawDigit, &lambda1);
-  initScreenItem(&motecItems[23], 10, 30, 20, redrawDigit, &lambda2);
-  initScreenItem(&motecItems[24], 10, 30, 20, redrawDigit, &lambda3);
-  initScreenItem(&motecItems[25], 10, 30, 20, redrawDigit, &lambda4);
-  initScreenItem(&motecItems[26], 10, 30, 20, redrawDigit, &lcEnablity);
-  initScreenItem(&motecItems[27], 10, 30, 20, redrawDigit, &fuelConsum);
-  initScreenItem(&motecItems[28], 10, 30, 20, redrawDigit, &gpsAltitude);
-  initScreenItem(&motecItems[29], 10, 30, 20, redrawDigit, &gpsTime);
-  initScreenItem(&motecItems[30], 10, 30, 20, redrawDigit, &fuelInjDuty);
-  initScreenItem(&motecItems[31], 10, 30, 20, redrawDigit, &fuelTrim);
 
   // End Race Screen
   allScreens[END_RACE_SCREEN] = &endRaceScreen;
@@ -523,20 +474,20 @@ void changeAUXType(uint8_t num){
       // Battery Voltage
       case 0:
         textWrite("BAT V");
-        raceScreenItems[6].data = &batVoltage;
+        raceScreenItems[6].data = &pdmDataItems[VBAT_RAIL_IDX];
         raceScreenItems[6].info.x += 30;
         break;
 
         // Lambda
       case 1:
         textWrite("LAMBDA");
-        raceScreenItems[6].data = &lambda;
+        raceScreenItems[6].data = &motecDataItems[LAMBDA_IDX];
         break;
 
         // RPM
       case 2:
         textWrite("RPM");
-        raceScreenItems[6].data = &rpm;
+        raceScreenItems[6].data = &motecDataItems[ENG_RPM_IDX];
         raceScreenItems[6].info.x -= 30;
         break;
     }
@@ -847,8 +798,8 @@ void endRace(void){
   endTireTempFR.value = ttFR.value;
   endTireTempRL.value = ttRL.value;
   endTireTempRR.value = ttRR.value;
-  endAmbientTemp.value = ambientTemp.value;
-  endFuelConsum.value = fuelConsum.value;
+  endAmbientTemp.value = motecDataItems[AIR_TEMP_IDX].value;
+  endFuelConsum.value = motecDataItems[FUEL_USED_IDX].value;
 }
 
 // Error Handling Stuff

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -143,37 +143,37 @@
 #define QUEUE_NT_IDX          11
 
 //MOTEC
-#define MOTEC_DATAITEM_SIZE   31
+#define MOTEC_DATAITEM_SIZE   29
 
-#define ENG_RPM_IDX           3
-#define THROTTLE_POS_IDX      4
-#define LAMBDA_IDX            5
-#define VOLT_ECU_IDX          6
-#define ENG_TEMP_IDX          7
-#define OIL_TEMP_IDX          8
-#define MANIFOLD_TEMP_IDX     9
-#define FUEL_TEMP_IDX         10
-#define AMBIENT_PRES_IDX      11
-#define OIL_PRES_IDX          12
-#define MANIFOLD_PRES_IDX     13
-#define FUEL_PRES_IDX         14
-#define WHEELSPEED_FL_IDX     15
-#define WHEELSPEED_FR_IDX     16
-#define WHEELSPEED_RL_IDX     17
-#define WHEELSPEED_RR_IDX     18
-#define DRIVE_SPEED_IDX       19
-#define GROUND_SPEED_IDX      20
-#define GPS_SPEED_IDX         21
-#define GPS_ALT_IDX           22
-#define GPS_LAT_IDX           23
-#define GPS_LONG_IDX          24
-#define GPS_TIME_IDX          25
-#define RUN_TIME_IDX          26
-#define FUEL_USED_IDX         27
-#define FUEL_INJ_DUTY_IDX     28
-#define FUEL_TRIM_IDX         29
-#define SHIFT_FORCE_IDX       30
-#define AIR_TEMP_IDX          31
+#define ENG_RPM_IDX           0
+#define THROTTLE_POS_IDX      1
+#define LAMBDA_IDX            2
+#define VOLT_ECU_IDX          3
+#define ENG_TEMP_IDX          4
+#define OIL_TEMP_IDX          5
+#define MANIFOLD_TEMP_IDX     6
+#define FUEL_TEMP_IDX         7
+#define AMBIENT_PRES_IDX      8
+#define OIL_PRES_IDX          9
+#define MANIFOLD_PRES_IDX     10
+#define FUEL_PRES_IDX         11
+#define WHEELSPEED_FL_IDX     12
+#define WHEELSPEED_FR_IDX     13
+#define WHEELSPEED_RL_IDX     14
+#define WHEELSPEED_RR_IDX     15
+#define DRIVE_SPEED_IDX       16
+#define GROUND_SPEED_IDX      17
+#define GPS_SPEED_IDX         18
+#define GPS_ALT_IDX           19
+#define GPS_LAT_IDX           20
+#define GPS_LONG_IDX          21
+#define GPS_TIME_IDX          22
+#define RUN_TIME_IDX          23
+#define FUEL_USED_IDX         24
+#define FUEL_INJ_DUTY_IDX     25
+#define FUEL_TRIM_IDX         26
+#define SHIFT_FORCE_IDX       27
+#define AIR_TEMP_IDX          28
 
 /*
  * Defines a data stream that is relevant to one or more screens
@@ -263,7 +263,7 @@ volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZ
 volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];
 
 // Uptimes
-volatile dataItem paddleUptime, loggerUptime, swUptime, pdmUptime;
+volatile dataItem loggerUptime, swUptime;
 
 // Tire Temps
 volatile dataItem ttFLA[4], ttFL, ttFRA[4], ttFR, ttRLA[4], ttRL, ttRRA[4], ttRR;

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -15,34 +15,36 @@
 #include "RA8875_driver.h"
 
 // Define race screen constants
-#define NUM_SCREENS 		8
-#define RACE_SCREEN 		0
-#define PDM_DRAW_SCREEN 	1
-#define PDM_CUT_SCREEN  	2
-#define MOTEC_SCREEN		3
-#define END_RACE_SCREEN		4
-#define CHASSIS_SCREEN		5
-#define GENERAL_SCREEN		6
-#define BRAKE_SCREEN		7
-#define MIN_REFRESH		100
+#define NUM_SCREENS           8
+#define RACE_SCREEN           0
+#define PDM_DRAW_SCREEN       1
+#define PDM_CUT_SCREEN        2
+#define MOTEC_SCREEN          3
+#define END_RACE_SCREEN       4
+#define CHASSIS_SCREEN        5
+#define GENERAL_SCREEN        6
+#define BRAKE_SCREEN          7
 
-#define MIN_SUS_POS		5
-#define MAX_SUS_POS		20
+#define MIN_REFRESH		        100
+
+#define MIN_SUS_POS		        5
+#define MAX_SUS_POS		        20
 
 #define MIN_BRAKE_PRESS     	0
 #define MAX_BRAKE_PRESS     	250
 
-#define REV_RANGE_1 7000
-#define REV_RANGE_2 8000
-#define REV_RANGE_3 9000
-#define REV_RANGE_4 10000
-#define REV_RANGE_5 10500
-#define REV_RANGE_6 11000
-#define REV_RANGE_7 11500
-#define REV_RANGE_8 12000
-#define REV_RANGE_9 12500
-#define REV_RANGE_REDLINE 13000
+#define REV_RANGE_1           7000
+#define REV_RANGE_2           8000
+#define REV_RANGE_3           9000
+#define REV_RANGE_4           10000
+#define REV_RANGE_5           10500
+#define REV_RANGE_6           11000
+#define REV_RANGE_7           11500
+#define REV_RANGE_8           12000
+#define REV_RANGE_9           12500
+#define REV_RANGE_REDLINE     13000
 
+// PDM Dataitem Constants
 #define PDM_DATAITEM_SIZE     93
 
 #define UPTIME_IDX            0
@@ -129,7 +131,7 @@
 #define BVBAT_OC_COUNT_IDX    91
 #define STR_OC_COUNT_IDX      92
 
-//GCM
+//GCM DataItem Constants
 #define GCM_DATAITEM_SIZE     12
 
 #define GEAR_IDX              3
@@ -142,7 +144,7 @@
 #define QUEUE_DN_IDX          10
 #define QUEUE_NT_IDX          11
 
-//MOTEC
+//MOTEC DataItem Constants
 #define MOTEC_DATAITEM_SIZE   29
 
 #define ENG_RPM_IDX           0
@@ -175,6 +177,7 @@
 #define SHIFT_FORCE_IDX       27
 #define AIR_TEMP_IDX          28
 
+//TireTemp DataItem Constants
 #define TIRETEMP_DATAITEM_SIZE  20
 
 #define FL                    0
@@ -198,6 +201,83 @@
 #define RR2                   18
 #define RR3                   19
 
+#define SPM_DATAITEM_SIZE       78
+                               
+#define ANALOG_CHAN_0_IDX       3
+#define ANALOG_CHAN_1_IDX       4
+#define ANALOG_CHAN_2_IDX       5
+#define ANALOG_CHAN_3_IDX       6
+#define ANALOG_CHAN_4_IDX       7
+#define ANALOG_CHAN_5_IDX       8
+#define ANALOG_CHAN_6_IDX       9
+#define ANALOG_CHAN_7_IDX       10
+#define ANALOG_CHAN_8_IDX       11
+#define ANALOG_CHAN_9_IDX       12
+#define ANALOG_CHAN_10_IDX      13
+#define ANALOG_CHAN_11_IDX      14
+#define ANALOG_CHAN_12_IDX      15
+#define ANALOG_CHAN_13_IDX      16
+#define ANALOG_CHAN_14_IDX      17
+#define ANALOG_CHAN_15_IDX      18
+#define ANALOG_CHAN_16_IDX      19
+#define ANALOG_CHAN_17_IDX      20
+#define ANALOG_CHAN_18_IDX      21
+#define ANALOG_CHAN_19_IDX      22
+#define ANALOG_CHAN_20_IDX      23
+#define ANALOG_CHAN_21_IDX      24
+#define ANALOG_CHAN_22_IDX      25
+#define ANALOG_CHAN_23_IDX      26
+#define ANALOG_CHAN_24_IDX      27
+#define ANALOG_CHAN_25_IDX      28
+#define ANALOG_CHAN_26_IDX      29
+#define ANALOG_CHAN_27_IDX      30
+#define ANALOG_CHAN_28_IDX      31
+#define ANALOG_CHAN_29_IDX      32
+#define ANALOG_CHAN_30_IDX      33
+#define ANALOG_CHAN_31_IDX      34
+#define ANALOG_CHAN_32_IDX      35
+#define ANALOG_CHAN_33_IDX      36
+#define ANALOG_CHAN_34_IDX      37
+#define ANALOG_CHAN_35_IDX      38
+#define TCOUPLE_0_IDX           39
+#define TCOUPLE_1_IDX           40
+#define TCOUPLE_2_IDX           41
+#define TCOUPLE_3_IDX           42
+#define TCOUPLE_4_IDX           43
+#define TCOUPLE_5_IDX           44
+#define AVG_JUNCT_TEMP_IDX      45
+#define TCOUPLE_0_FAULT_IDX     46
+#define TCOUPLE_1_FAULT_IDX     47
+#define TCOUPLE_2_FAULT_IDX     48
+#define TCOUPLE_3_FAULT_IDX     49
+#define TCOUPLE_4_FAULT_IDX     50
+#define TCOUPLE_5_FAULT_IDX     51
+#define DIGITAL_INPUT_0_IDX     52
+#define DIGITAL_INPUT_1_IDX     53
+#define DIGITAL_INPUT_2_IDX     54
+#define DIGITAL_INPUT_3_IDX     55
+#define DIGITAL_INPUT_4_IDX     56
+#define DIGITAL_INPUT_5_IDX     57
+#define DIGITAL_INPUT_6_IDX     58
+#define DIGITAL_INPUT_7_IDX     59
+#define DIGITAL_INPUT_8_IDX     60
+#define DIGITAL_INPUT_9_IDX     61
+#define DIGITAL_INPUT_10_IDX    62
+#define DIGITAL_INPUT_11_IDX    63
+#define DIGITAL_INPUT_12_IDX    64
+#define DIGITAL_INPUT_13_IDX    65
+#define DIGITAL_INPUT_14_IDX    66
+#define DIGITAL_INPUT_15_IDX    67
+#define FREQ_COUNT_0_IDX        68
+#define FREQ_COUNT_1_IDX        69
+#define FREQ_COUNT_2_IDX        70
+#define PGA_0_SETTINGS_IDX      71
+#define PGA_1_SETTINGS_IDX      72
+#define PGA_2_SETTINGS_IDX      73
+#define PGA_3_SETTINGS_IDX      74
+#define FREQ_0_SETTINGS_IDX     75
+#define FREQ_1_SETTINGS_IDX     76
+#define FREQ_2_SETTINGS_IDX     77
 
 /*
  * Defines a data stream that is relevant to one or more screens
@@ -262,14 +342,6 @@ typedef struct {
 	uint8_t len;
 } screen;
 
-/*
-typedef struct {
-	char * errText;
-	dataItem * item;
-	uint8_t priority;
-} errMsg;
-*/
-
 // Define all screen item arrays for each screen
 screenItem raceScreenItems[10], pdmDrawItems[20], pdmCutItems[21], brakeItems[8], motecItems[30], endRaceItems[9], chassisItems[20], generalItems[7];
 // Define all screen structs
@@ -281,7 +353,7 @@ uint8_t screenNumber, auxNumber;
 
 volatile uint16_t backgroundColor, foregroundColor, warningColor, errorColor;
 
-volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE], motecDataItems[MOTEC_DATAITEM_SIZE], tireTempDataItems[TIRETEMP_DATAITEM_SIZE];
+volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE], motecDataItems[MOTEC_DATAITEM_SIZE], tireTempDataItems[TIRETEMP_DATAITEM_SIZE], spmDataItems[SPM_DATAITEM_SIZE];
 
 // General Items
 volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -175,6 +175,30 @@
 #define SHIFT_FORCE_IDX       27
 #define AIR_TEMP_IDX          28
 
+#define TIRETEMP_DATAITEM_SIZE  20
+
+#define FL                    0
+#define FL0                   1
+#define FL1                   2
+#define FL2                   3
+#define FL3                   4
+#define FR                    5
+#define FR0                   6
+#define FR1                   7
+#define FR2                   8
+#define FR3                   9
+#define RL                    10
+#define RL0                   11
+#define RL1                   12
+#define RL2                   13
+#define RL3                   14
+#define RR                    15
+#define RR0                   16
+#define RR1                   17
+#define RR2                   18
+#define RR3                   19
+
+
 /*
  * Defines a data stream that is relevant to one or more screens
  *
@@ -257,7 +281,7 @@ uint8_t screenNumber, auxNumber;
 
 volatile uint16_t backgroundColor, foregroundColor, warningColor, errorColor;
 
-volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE], motecDataItems[MOTEC_DATAITEM_SIZE];
+volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE], motecDataItems[MOTEC_DATAITEM_SIZE], tireTempDataItems[TIRETEMP_DATAITEM_SIZE];
 
 // General Items
 volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];
@@ -265,13 +289,8 @@ volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];
 // Uptimes
 volatile dataItem loggerUptime, swUptime;
 
-// Tire Temps
-volatile dataItem ttFLA[4], ttFL, ttFRA[4], ttFR, ttRLA[4], ttRL, ttRRA[4], ttRR;
-
 // Wheel Buttons
 volatile dataItem rotary[3], tRotary[2], switches[4], momentaries[4];
-
-volatile dataItem FUELOCCount, IGNOCCount, INJOCCount, ABSOCCount, PDLUOCCount, PDLDOCCount, FANOCCount, WTROCCount, ECUOCCount, AUXOCCount, BVBATOCCount, STROCCount;
 
 // Rear Analog Hub
 volatile dataItem susPosRR, susPosRL, engOutput, battCurrent, radInputTemp, radOutputTemp, swirlTemp, swirlPress;

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -25,13 +25,13 @@
 #define GENERAL_SCREEN        6
 #define BRAKE_SCREEN          7
 
-#define MIN_REFRESH		        100
+#define MIN_REFRESH           100
 
-#define MIN_SUS_POS		        5
-#define MAX_SUS_POS		        20
+#define MIN_SUS_POS           5
+#define MAX_SUS_POS           20
 
-#define MIN_BRAKE_PRESS     	0
-#define MAX_BRAKE_PRESS     	250
+#define MIN_BRAKE_PRESS       0
+#define MAX_BRAKE_PRESS       250
 
 #define REV_RANGE_1           7000
 #define REV_RANGE_2           8000
@@ -282,64 +282,64 @@
 /*
  * Defines a data stream that is relevant to one or more screens
  *
- * value - 		double value of stream
- * warnThreshold - 	Value where data will enter a warning state
- * errThreshold - 	Value where data will enter an error state
- * refreshInterval -	Maximum refresh frequency
- * wholeDigits - 	Number of whole digits to display
- * decDigits - 		Number of decimal digits to display
+ * value -    double value of stream
+ * warnThreshold -  Value where data will enter a warning state
+ * errThreshold -   Value where data will enter an error state
+ * refreshInterval -  Maximum refresh frequency
+ * wholeDigits -  Number of whole digits to display
+ * decDigits -    Number of decimal digits to display
  */
 typedef struct {
-	double value;
-	double warnThreshold;
-	double errThreshold;
-	uint32_t refreshInterval;
-	uint8_t wholeDigits;
-	uint8_t decDigits;
+  double value;
+  double warnThreshold;
+  double errThreshold;
+  uint32_t refreshInterval;
+  uint8_t wholeDigits;
+  uint8_t decDigits;
 } dataItem;
 
 
 /*
  * Defines the minimum amount of information a redrawItem function needs to work
  *
- * x -		X coordinate
- * y - 		Y coordinate
- * size - 	Size of item
+ * x -    X coordinate
+ * y -    Y coordinate
+ * size -   Size of item
  */
 
 typedef struct {
-	uint16_t x;
-	uint16_t y;
-	uint16_t size;
+  uint16_t x;
+  uint16_t y;
+  uint16_t size;
 } screenItemInfo;
 
 
 /*
  * Defines an item that will be displayed on a specific screen
  *
- * currentValue - 	Current value being displayed
- * data - 		Pointer to corresponding dataItem
- * refreshTime -	Time that the value was previously refreshed
- * info - 		Struct that contains necessary info for redrawing
- * redrawItem - 	Redraw function pointer, called when the item is refreshed
+ * currentValue -   Current value being displayed
+ * data -     Pointer to corresponding dataItem
+ * refreshTime -  Time that the value was previously refreshed
+ * info -     Struct that contains necessary info for redrawing
+ * redrawItem -   Redraw function pointer, called when the item is refreshed
  */
 typedef struct {
-	double currentValue;
-	volatile dataItem * data;
-	uint32_t refreshTime;
-	screenItemInfo info;
-	void (*redrawItem)(screenItemInfo *, volatile dataItem *, double);
+  double currentValue;
+  volatile dataItem * data;
+  uint32_t refreshTime;
+  screenItemInfo info;
+  void (*redrawItem)(screenItemInfo *, volatile dataItem *, double);
 } screenItem;
 
 /*
  * Defines a screen
  *
- * items -	Array of screen Items that will be on that screen
- * len - 	Length of screenItem array
+ * items -  Array of screen Items that will be on that screen
+ * len -  Length of screenItem array
  */
 typedef struct {
-	screenItem * items;
-	uint8_t len;
+  screenItem * items;
+  uint8_t len;
 } screen;
 
 // Define all screen item arrays for each screen
@@ -380,14 +380,14 @@ uint8_t lapTimeHead, numLaps;
 void initDataItems(void); // Writes default values to all data items
 // Initializes an individual dataItem
 void initDataItem(volatile dataItem* data, double warn, double err,
-	uint32_t refresh, uint8_t whole, uint8_t dec);
+  uint32_t refresh, uint8_t whole, uint8_t dec);
 void setDataItemDigits(volatile dataItem* data, uint8_t whole, uint8_t dec);
 void initAllScreens(void); // Initializes all screenItems
 void initScreen(uint8_t num); // Draws all non-dataItem data to start a screen
 // Initializes an individual screenItem
 void initScreenItem(screenItem* item, uint16_t x, uint16_t y, uint16_t size,
-	void (*redrawItem)(screenItemInfo *, volatile dataItem *, double),
-	volatile dataItem* data);
+  void (*redrawItem)(screenItemInfo *, volatile dataItem *, double),
+  volatile dataItem* data);
 // Toggles between a few different data items on one screen
 void changeAUXType(uint8_t num);
 void changeScreen(uint8_t num);

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -43,6 +43,92 @@
 #define REV_RANGE_9 12500
 #define REV_RANGE_REDLINE 13000
 
+#define PDM_DATAITEM_SIZE     93
+
+#define UPTIME_IDX            0
+#define PCB_TEMP_IDX          1
+#define IC_TEMP_IDX           2
+#define STR_ENABLITY_IDX      3
+#define BVBAT_ENABLITY_IDX    4
+#define AUX_ENABLITY_IDX      5
+#define ECU_ENABLITY_IDX      6
+#define WTR_ENABLITY_IDX      7
+#define FAN_ENABLITY_IDX      8
+#define PDLD_ENABLITY_IDX     9
+#define PDLU_ENABLITY_IDX     10
+#define ABS_ENABLITY_IDX      11
+#define INJ_ENABLITY_IDX      12
+#define IGN_ENABLITY_IDX      13
+#define FUEL_ENABLITY_IDX     14
+#define STR_PEAK_MODE_IDX     15
+#define BVBAT_PEAK_MODE_IDX   16
+#define AUX_PEAK_MODE_IDX     17
+#define ECU_PEAK_MODE_IDX     18
+#define WTR_PEAK_MODE_IDX     19
+#define FAN_PEAK_MODE_IDX     20
+#define PDLD_PEAK_MODE_IDX    21
+#define PDLU_PEAK_MODE_IDX    22
+#define ABS_PEAK_MODE_IDX     23
+#define INJ_PEAK_MODE_IDX     24
+#define IGN_PEAK_MODE_IDX     25
+#define FUEL_PEAK_MODE_IDX    26
+#define TOTAL_CURRENT_IDX     27
+#define AUX2_SWITCH_IDX       28
+#define AUX1_SWITCH_IDX       29
+#define ABS_SWITCH_IDX        30
+#define KILL_SWITCH_IDX       31
+#define ACT_DN_SWITCH_IDX     32
+#define ACT_UP_SWITCH_IDX     33
+#define ON_SWITCH_IDX         34
+#define STR_SWITCH_IDX        35
+#define KILL_ENGINE_FLAG_IDX  36
+#define KILL_CAR_FLAG_IDX     37
+#define OVER_TEMP_FLAG_IDX    38
+#define FUEL_PRIME_FLAG_IDX   39
+#define VBAT_RAIL_IDX         40
+#define V12_RAIL_IDX          41
+#define V5_RAIL_IDX           42
+#define V3V3_RAIL_IDX         43
+#define FUEL_DRAW_IDX         44
+#define IGN_DRAW_IDX          45
+#define INJ_DRAW_IDX          46
+#define ABS_DRAW_IDX          47
+#define PDLU_DRAW_IDX         48
+#define PDLD_DRAW_IDX         49
+#define FAN_DRAW_IDX          50
+#define WTR_DRAW_IDX          51
+#define ECU_DRAW_IDX          52
+#define AUX_DRAW_IDX          53
+#define BVBAT_DRAW_IDX        54
+#define STR_DRAW_IDX          55
+#define FUEL_CUT_IDX          56
+#define IGN_CUT_IDX           57
+#define INJ_CUT_IDX           58
+#define ABS_CUT_IDX           59
+#define PDLU_CUT_IDX          60
+#define PDLD_CUT_IDX          61
+#define FAN_CUT_IDX           62
+#define WTR_CUT_IDX           63
+#define ECU_CUT_IDX           64
+#define AUX_CUT_IDX           65
+#define BVBAT_CUT_IDX         66
+#define FUEL_CUT_P_IDX        67
+#define FAN_CUT_P_IDX         68
+#define WTR_CUT_P_IDX         69
+#define ECU_CUT_P_IDX         80
+#define FUEL_OC_COUNT_IDX     81
+#define IGN_OC_COUNT_IDX      82
+#define INJ_OC_COUNT_IDX      83
+#define ABS_OC_COUNT_IDX      84
+#define PDLU_OC_COUNT_IDX     85
+#define PDLD_OC_COUNT_IDX     86
+#define FAN_OC_COUNT_IDX      87
+#define WTR_OC_COUNT_IDX      88
+#define ECU_OC_COUNT_IDX      89
+#define AUX_OC_COUNT_IDX      90
+#define BVBAT_OC_COUNT_IDX    91
+#define STR_OC_COUNT_IDX      92
+
 /*
  * Defines a data stream that is relevant to one or more screens
  *
@@ -125,6 +211,8 @@ uint8_t screenNumber, auxNumber;
 
 volatile uint16_t backgroundColor, foregroundColor, warningColor, errorColor;
 
+volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE];
+
 // General Items
 volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];
 
@@ -139,12 +227,6 @@ volatile dataItem ttFLA[4], ttFL, ttFRA[4], ttFR, ttRLA[4], ttRL, ttRRA[4], ttRR
 
 // Wheel Buttons
 volatile dataItem rotary[3], tRotary[2], switches[4], momentaries[4];
-
-// PDM
-volatile dataItem pdmTemp, pdmICTemp, pdmCurrentDraw, pdmVBat, pdm12v, pdm5v5, pdm5v, pdm3v3, pdmIGNdraw, pdmIGNcut, pdmINJdraw, pdmINJcut, pdmFUELdraw, pdmFUELcut, pdmFUELPcut, pdmECUdraw, pdmECUcut, pdmECUPcut, pdmWTRdraw, pdmWTRcut, pdmWTRPcut, pdmFANdraw, pdmFANcut, pdmFANPcut, pdmAUXdraw, pdmAUXcut, pdmPDLUdraw, pdmPDLUcut, pdmPDLDdraw, pdmPDLDcut, pdm5v5draw, pdm5v5cut, pdmBATdraw, pdmBATcut, pdmSTRdraw, pdmSTRcut, pdmTOTdraw, pdmABSdraw, pdmABScut, pdmBVBATdraw, pdmBVBATcut;
-
-// PDM Bitmaps
-volatile dataItem STRenabl, BVBATenabl, PDLDenabl, PDLUenabl, AUXenabl, ABSenabl, FANenabl, WTRenabl, ECUenabl, FUELenabl, INJenabl, IGNenabl, STRpm, BVBATpm, B5V5pm, PDLDpm, PDLUpm, ABSpm, AUXpm, FANpm, WTRpm, ECUpm, FUELpm, INJpm, IGNpm, KILLpdmSw, ACT_DNpdmSw, ACT_UPpdmSw, ONpdmSw, STRpdmSw, AUX1pdmSw, AUX2pdmSw, ABSpdmSw, KillEngineFlag, KillCarFlag, OverTempFlag, FuelPrimeFlag;
 
 volatile dataItem FUELOCCount, IGNOCCount, INJOCCount, ABSOCCount, PDLUOCCount, PDLDOCCount, FANOCCount, WTROCCount, ECUOCCount, AUXOCCount, BVBATOCCount, STROCCount;
 

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -142,6 +142,39 @@
 #define QUEUE_DN_IDX          10
 #define QUEUE_NT_IDX          11
 
+//MOTEC
+#define MOTEC_DATAITEM_SIZE   31
+
+#define ENG_RPM_IDX           3
+#define THROTTLE_POS_IDX      4
+#define LAMBDA_IDX            5
+#define VOLT_ECU_IDX          6
+#define ENG_TEMP_IDX          7
+#define OIL_TEMP_IDX          8
+#define MANIFOLD_TEMP_IDX     9
+#define FUEL_TEMP_IDX         10
+#define AMBIENT_PRES_IDX      11
+#define OIL_PRES_IDX          12
+#define MANIFOLD_PRES_IDX     13
+#define FUEL_PRES_IDX         14
+#define WHEELSPEED_FL_IDX     15
+#define WHEELSPEED_FR_IDX     16
+#define WHEELSPEED_RL_IDX     17
+#define WHEELSPEED_RR_IDX     18
+#define DRIVE_SPEED_IDX       19
+#define GROUND_SPEED_IDX      20
+#define GPS_SPEED_IDX         21
+#define GPS_ALT_IDX           22
+#define GPS_LAT_IDX           23
+#define GPS_LONG_IDX          24
+#define GPS_TIME_IDX          25
+#define RUN_TIME_IDX          26
+#define FUEL_USED_IDX         27
+#define FUEL_INJ_DUTY_IDX     28
+#define FUEL_TRIM_IDX         29
+#define SHIFT_FORCE_IDX       30
+#define AIR_TEMP_IDX          31
+
 /*
  * Defines a data stream that is relevant to one or more screens
  *
@@ -224,16 +257,13 @@ uint8_t screenNumber, auxNumber;
 
 volatile uint16_t backgroundColor, foregroundColor, warningColor, errorColor;
 
-volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE];
+volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE], motecDataItems[MOTEC_DATAITEM_SIZE];
 
 // General Items
 volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];
 
 // Uptimes
 volatile dataItem paddleUptime, loggerUptime, swUptime, pdmUptime;
-
-// Motec Data Stream
-volatile dataItem rpm, throtPos, oilPress, oilTemp, waterTemp, lambda, manifoldPress, batVoltage, wheelSpeedFL, wheelSpeedFR, wheelSpeedRL, wheelSpeedRR, gpsLat, gpsLong, groundSpeed, driveSpeed, gpsSpeed, manifoldTemp, ambientTemp, ambientPress, fuelTemp, fuelPress, lambda1, lambda2, lambda3, lambda4, lcEnablity, fuelConsum, gpsAltitude, gpsTime, runTime, fuelInjDuty, fuelTrim;
 
 // Tire Temps
 volatile dataItem ttFLA[4], ttFL, ttFRA[4], ttFR, ttRLA[4], ttRL, ttRRA[4], ttRR;
@@ -260,6 +290,7 @@ void initDataItems(void); // Writes default values to all data items
 // Initializes an individual dataItem
 void initDataItem(volatile dataItem* data, double warn, double err,
 	uint32_t refresh, uint8_t whole, uint8_t dec);
+void setDataItemDigits(volatile dataItem* data, uint8_t whole, uint8_t dec);
 void initAllScreens(void); // Initializes all screenItems
 void initScreen(uint8_t num); // Draws all non-dataItem data to start a screen
 // Initializes an individual screenItem

--- a/Wheel_Node.X/FSAE_LCD.h
+++ b/Wheel_Node.X/FSAE_LCD.h
@@ -129,6 +129,19 @@
 #define BVBAT_OC_COUNT_IDX    91
 #define STR_OC_COUNT_IDX      92
 
+//GCM
+#define GCM_DATAITEM_SIZE     12
+
+#define GEAR_IDX              3
+#define GEAR_VOLT_IDX         4
+#define FORCE_IDX             5
+#define PADDLE_UP_SW_IDX      6
+#define PADDLE_DOWN_SW_IDX    7
+#define NEUTRAL_SW_IDX        8
+#define QUEUE_UP_IDX          9
+#define QUEUE_DN_IDX          10
+#define QUEUE_NT_IDX          11
+
 /*
  * Defines a data stream that is relevant to one or more screens
  *
@@ -211,7 +224,7 @@ uint8_t screenNumber, auxNumber;
 
 volatile uint16_t backgroundColor, foregroundColor, warningColor, errorColor;
 
-volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE];
+volatile dataItem pdmDataItems[PDM_DATAITEM_SIZE], gcmDataItems[GCM_DATAITEM_SIZE];
 
 // General Items
 volatile dataItem * fanSw[2], * fuelSw[2], * wtrSw[2];
@@ -235,9 +248,6 @@ volatile dataItem susPosRR, susPosRL, engOutput, battCurrent, radInputTemp, radO
 
 // Front Analog Hub
 volatile dataItem susPosFR, susPosFL, brakePressFront, brakePressRear, brakeMaxFront, brakeMinFront,brakeMaxRear, brakeMinRear, steeringAngle, accelPedalPos0, accelPedalPos1;
-
-// Paddle Shifting
-volatile dataItem paddleTemp, gearPos, neutQueue, upQueue, downQueue, gearVoltage;
 
 // End Race Data
 volatile dataItem endLogNum, endNumLaps, endFastLap, endTireTempFL, endTireTempFR, endTireTempRL, endTireTempRR, endAmbientTemp, endFuelConsum;

--- a/Wheel_Node.X/Wheel.c
+++ b/Wheel_Node.X/Wheel.c
@@ -32,12 +32,12 @@ void main(void) {
   auxNumber = 0;
 
   // Init Relevant Pins
-  LCD_CS_TRIS = OUTPUT;
   LCD_CS_LAT = 1;
-  LCD_RST_TRIS = OUTPUT;
+  LCD_CS_TRIS = OUTPUT;
   LCD_RST_LAT = 1;
-  LCD_PWM_TRIS = OUTPUT;
+  LCD_RST_TRIS = OUTPUT;
   LCD_PWM_LAT = 1; //TODO: This is full brightness, PWM for other settings
+  LCD_PWM_TRIS = OUTPUT;
 
   SW1_TRIS = INPUT;
   SW2_TRIS = INPUT;
@@ -71,7 +71,6 @@ void main(void) {
   GPIOX(1);// Enable TFT - display enable tied to GPIOX
 
   //fillScreen(RA8875_BLACK);
-  //drawChevron(150,15,130,200,RA8875_RED,RA8875_BLACK);
 
   // Initialize All the data streams
   initDataItems();
@@ -168,9 +167,8 @@ void __attribute__((vector(_CAN1_VECTOR), interrupt(IPL4SRS))) can_inthnd(void) 
 void process_CAN_msg(CAN_message msg){
   uint16_t * lsbArray = (uint16_t *) msg.data;
   switch (msg.id) {
-    /*
 
-    /*Motec Paddle Shifting*/
+    /*Motec*/
     case MOTEC_ID + 0:
       motecDataItems[ENG_RPM_IDX].value = parseMsgMotec(&msg, ENG_RPM_BYTE, ENG_RPM_SCL);
       motecDataItems[THROTTLE_POS_IDX].value = parseMsgMotec(&msg, THROTTLE_POS_BYTE, THROTTLE_POS_SCL);
@@ -215,7 +213,7 @@ void process_CAN_msg(CAN_message msg){
       motecDataItems[AIR_TEMP_IDX].value = parseMsgMotec(&msg, AIR_TEMP_BYTE, AIR_TEMP_SCL);
       break;
 
-      /*GCM ID's*/
+      /*GCM*/
     case GCM_ID:
       gcmDataItems[UPTIME_IDX].value = (uint16_t) (lsbArray[UPTIME_BYTE/2]) * UPTIME_SCL;
       gcmDataItems[PCB_TEMP_IDX].value = (int16_t) (lsbArray[PCB_TEMP_BYTE/2]) * PCB_TEMP_SCL;
@@ -227,15 +225,15 @@ void process_CAN_msg(CAN_message msg){
       gcmDataItems[FORCE_IDX].value = (int16_t) (lsbArray[FORCE_BYTE/2]) * FORCE_SCL;
       break;
     case GCM_ID + 2:
-      gcmDataItems[PADDLE_UP_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & PADDLE_UP_GCM_SW_BIT;
-      gcmDataItems[PADDLE_DOWN_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & PADDLE_DOWN_GCM_SW_BIT;
-      gcmDataItems[NEUTRAL_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & NEUTRAL_GCM_SW_BIT;
+      gcmDataItems[PADDLE_UP_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & PADDLE_UP_GCM_SW_MASK;
+      gcmDataItems[PADDLE_DOWN_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & PADDLE_DOWN_GCM_SW_MASK;
+      gcmDataItems[NEUTRAL_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & NEUTRAL_GCM_SW_MASK;
       gcmDataItems[QUEUE_UP_IDX].value = (uint8_t) (msg.data[QUEUE_UP_BYTE]) * QUEUE_UP_SCL;
       gcmDataItems[QUEUE_DN_IDX].value = (uint8_t) (msg.data[QUEUE_DN_BYTE]) * QUEUE_DN_SCL;
       gcmDataItems[QUEUE_NT_IDX].value = (uint8_t) (msg.data[QUEUE_NT_BYTE]) * QUEUE_NT_SCL;
       break;
 
-      /*PDM ID's*/
+      /*PDM*/
     case PDM_ID:
       pdmDataItems[UPTIME_IDX].value = (uint16_t) (lsbArray[UPTIME_BYTE/2]) * UPTIME_SCL;
       pdmDataItems[PCB_TEMP_IDX].value = (int16_t) (lsbArray[PCB_TEMP_BYTE/2]) * PCB_TEMP_SCL;
@@ -244,51 +242,51 @@ void process_CAN_msg(CAN_message msg){
     case PDM_ID + 1:
 
       // Enablity
-      pdmDataItems[STR_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & STR_ENBL_BIT;
-      pdmDataItems[BVBAT_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & BVBAT_ENBL_BIT;
-      pdmDataItems[AUX_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & AUX_ENBL_BIT;
-      pdmDataItems[ECU_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & ECU_ENBL_BIT;
-      pdmDataItems[WTR_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & WTR_ENBL_BIT;
-      pdmDataItems[FAN_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & FAN_ENBL_BIT;
-      pdmDataItems[PDLD_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLD_ENBL_BIT;
-      pdmDataItems[PDLU_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLU_ENBL_BIT;
-      pdmDataItems[ABS_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & ABS_ENBL_BIT;
-      pdmDataItems[INJ_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & INJ_ENBL_BIT;
-      pdmDataItems[IGN_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & IGN_ENBL_BIT;
-      pdmDataItems[FUEL_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & FUEL_ENBL_BIT;
+      pdmDataItems[STR_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & STR_ENBL_MASK;
+      pdmDataItems[BVBAT_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & BVBAT_ENBL_MASK;
+      pdmDataItems[AUX_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & AUX_ENBL_MASK;
+      pdmDataItems[ECU_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & ECU_ENBL_MASK;
+      pdmDataItems[WTR_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & WTR_ENBL_MASK;
+      pdmDataItems[FAN_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & FAN_ENBL_MASK;
+      pdmDataItems[PDLD_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLD_ENBL_MASK;
+      pdmDataItems[PDLU_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLU_ENBL_MASK;
+      pdmDataItems[ABS_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & ABS_ENBL_MASK;
+      pdmDataItems[INJ_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & INJ_ENBL_MASK;
+      pdmDataItems[IGN_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & IGN_ENBL_MASK;
+      pdmDataItems[FUEL_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & FUEL_ENBL_MASK;
 
       // Peak Mode
-      pdmDataItems[STR_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & STR_PEAKM_BIT;
-      pdmDataItems[BVBAT_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & BVBAT_PEAKM_BIT;
-      pdmDataItems[AUX_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & AUX_PEAKM_BIT;
-      pdmDataItems[ECU_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & ECU_PEAKM_BIT;
-      pdmDataItems[WTR_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & WTR_PEAKM_BIT;
-      pdmDataItems[FAN_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & FAN_PEAKM_BIT;
-      pdmDataItems[PDLD_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & PDLD_PEAKM_BIT;
-      pdmDataItems[PDLU_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & PDLU_PEAKM_BIT;
-      pdmDataItems[ABS_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & ABS_PEAKM_BIT;
-      pdmDataItems[INJ_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & INJ_PEAKM_BIT;
-      pdmDataItems[IGN_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & IGN_PEAKM_BIT;
-      pdmDataItems[FUEL_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & FUEL_PEAKM_BIT;
+      pdmDataItems[STR_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & STR_PEAKM_MASK;
+      pdmDataItems[BVBAT_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & BVBAT_PEAKM_MASK;
+      pdmDataItems[AUX_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & AUX_PEAKM_MASK;
+      pdmDataItems[ECU_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & ECU_PEAKM_MASK;
+      pdmDataItems[WTR_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & WTR_PEAKM_MASK;
+      pdmDataItems[FAN_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & FAN_PEAKM_MASK;
+      pdmDataItems[PDLD_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & PDLD_PEAKM_MASK;
+      pdmDataItems[PDLU_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & PDLU_PEAKM_MASK;
+      pdmDataItems[ABS_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & ABS_PEAKM_MASK;
+      pdmDataItems[INJ_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & INJ_PEAKM_MASK;
+      pdmDataItems[IGN_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & IGN_PEAKM_MASK;
+      pdmDataItems[FUEL_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & FUEL_PEAKM_MASK;
 
       // Total current
       pdmDataItems[TOTAL_CURRENT_IDX].value = (uint16_t) (lsbArray[TOTAL_CURRENT_BYTE/2]) * TOTAL_CURRENT_SCL;
 
       // Switch bitmap
-      pdmDataItems[AUX2_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & AUX2_PDM_SW_BIT;
-      pdmDataItems[AUX1_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & AUX1_PDM_SW_BIT;
-      pdmDataItems[ABS_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ABS_PDM_SW_BIT;
-      pdmDataItems[KILL_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & KILL_PDM_SW_BIT;
-      pdmDataItems[ACT_DN_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ACT_DN_PDM_SW_BIT;
-      pdmDataItems[ACT_UP_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ACT_UP_PDM_SW_BIT;
-      pdmDataItems[ON_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ON_PDM_SW_BIT;
-      pdmDataItems[STR_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & STR_PDM_SW_BIT;
+      pdmDataItems[AUX2_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & AUX2_PDM_SW_MASK;
+      pdmDataItems[AUX1_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & AUX1_PDM_SW_MASK;
+      pdmDataItems[ABS_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ABS_PDM_SW_MASK;
+      pdmDataItems[KILL_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & KILL_PDM_SW_MASK;
+      pdmDataItems[ACT_DN_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ACT_DN_PDM_SW_MASK;
+      pdmDataItems[ACT_UP_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ACT_UP_PDM_SW_MASK;
+      pdmDataItems[ON_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ON_PDM_SW_MASK;
+      pdmDataItems[STR_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & STR_PDM_SW_MASK;
 
       // Flags
-      pdmDataItems[KILL_ENGINE_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & KILL_ENGINE_PDM_FLAG_BIT;
-      pdmDataItems[KILL_CAR_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & KILL_CAR_PDM_FLAG_BIT;
-      pdmDataItems[OVER_TEMP_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & OVER_TEMP_PDM_FLAG_BIT;
-      pdmDataItems[FUEL_PRIME_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & FUEL_PRIME_PDM_FLAG_BIT;
+      pdmDataItems[KILL_ENGINE_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & KILL_ENGINE_PDM_FLAG_MASK;
+      pdmDataItems[KILL_CAR_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & KILL_CAR_PDM_FLAG_MASK;
+      pdmDataItems[OVER_TEMP_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & OVER_TEMP_PDM_FLAG_MASK;
+      pdmDataItems[FUEL_PRIME_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & FUEL_PRIME_PDM_FLAG_MASK;
       break;
     case PDM_ID + 2:
       pdmDataItems[VBAT_RAIL_IDX].value = (uint16_t) (lsbArray[VBAT_RAIL_BYTE/2]) * VBAT_RAIL_SCL;
@@ -356,32 +354,140 @@ void process_CAN_msg(CAN_message msg){
 
       /*Tire Temps*/
     case TIRE_TEMP_FL_ID:
-      tireTempDataItems[FL0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[FL1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[FL2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[FL3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FL0].value = (double) (lsbArray[TIRE_TEMP_1_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[FL1].value = (double) (lsbArray[TIRE_TEMP_2_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[FL2].value = (double) (lsbArray[TIRE_TEMP_3_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[FL3].value = (double) (lsbArray[TIRE_TEMP_4_BYTE/2]*TIRE_TEMP_SCL);
       tireTempDataItems[FL].value = (tireTempDataItems[FL0].value + tireTempDataItems[FL1].value + tireTempDataItems[FL2].value + tireTempDataItems[FL3].value)/4.0;
       break;
     case TIRE_TEMP_FR_ID:
-      tireTempDataItems[FR0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[FR1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[FR2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[FR3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FR0].value = (double) (lsbArray[TIRE_TEMP_1_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[FR1].value = (double) (lsbArray[TIRE_TEMP_2_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[FR2].value = (double) (lsbArray[TIRE_TEMP_3_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[FR3].value = (double) (lsbArray[TIRE_TEMP_4_BYTE/2]*TIRE_TEMP_SCL);
       tireTempDataItems[FR].value = (tireTempDataItems[FR0].value + tireTempDataItems[FR1].value + tireTempDataItems[FR2].value + tireTempDataItems[FR3].value)/4.0;
       break;
     case TIRE_TEMP_RL_ID:
-      tireTempDataItems[RL0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[RL1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[RL2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[RL3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RL0].value = (double) (lsbArray[TIRE_TEMP_1_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[RL1].value = (double) (lsbArray[TIRE_TEMP_2_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[RL2].value = (double) (lsbArray[TIRE_TEMP_3_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[RL3].value = (double) (lsbArray[TIRE_TEMP_4_BYTE/2]*TIRE_TEMP_SCL);
       tireTempDataItems[RL].value = (tireTempDataItems[RL0].value + tireTempDataItems[RL1].value + tireTempDataItems[RL2].value + tireTempDataItems[RL3].value)/4.0;
       break;
     case TIRE_TEMP_RR_ID:
-      tireTempDataItems[RR0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[RR1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[RR2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      tireTempDataItems[RR3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RR0].value = (double) (lsbArray[TIRE_TEMP_1_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[RR1].value = (double) (lsbArray[TIRE_TEMP_2_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[RR2].value = (double) (lsbArray[TIRE_TEMP_3_BYTE/2]*TIRE_TEMP_SCL);
+      tireTempDataItems[RR3].value = (double) (lsbArray[TIRE_TEMP_4_BYTE/2]*TIRE_TEMP_SCL);
       tireTempDataItems[RR].value = (tireTempDataItems[RR0].value + tireTempDataItems[RR1].value + tireTempDataItems[RR2].value + tireTempDataItems[RR3].value)/4.0;
+      break;
+
+      // SPM
+    case SPM_ID:
+      spmDataItems[UPTIME_IDX].value = (uint16_t) (lsbArray[UPTIME_BYTE/2]) * UPTIME_SCL;
+      spmDataItems[PCB_TEMP_IDX].value = (int16_t) (lsbArray[PCB_TEMP_BYTE/2]) * PCB_TEMP_SCL;
+      spmDataItems[IC_TEMP_IDX].value = (int16_t) (lsbArray[IC_TEMP_BYTE/2]) * IC_TEMP_SCL;
+      break;
+    case SPM_ID + 1:
+      spmDataItems[ANALOG_CHAN_0_IDX].value = (double) (lsbArray[ANALOG_CHAN_0_BYTE/2] * ANALOG_CHAN_0_SCL);
+      spmDataItems[ANALOG_CHAN_1_IDX].value = (double) (lsbArray[ANALOG_CHAN_1_BYTE/2] * ANALOG_CHAN_1_SCL);
+      spmDataItems[ANALOG_CHAN_2_IDX].value = (double) (lsbArray[ANALOG_CHAN_2_BYTE/2] * ANALOG_CHAN_2_SCL);
+      spmDataItems[ANALOG_CHAN_3_IDX].value = (double) (lsbArray[ANALOG_CHAN_3_BYTE/2] * ANALOG_CHAN_3_SCL);
+      break;
+    case SPM_ID + 2:
+      spmDataItems[ANALOG_CHAN_4_IDX].value = (double) (lsbArray[ANALOG_CHAN_4_BYTE/2] * ANALOG_CHAN_4_SCL);
+      spmDataItems[ANALOG_CHAN_5_IDX].value = (double) (lsbArray[ANALOG_CHAN_5_BYTE/2] * ANALOG_CHAN_5_SCL);
+      spmDataItems[ANALOG_CHAN_6_IDX].value = (double) (lsbArray[ANALOG_CHAN_6_BYTE/2] * ANALOG_CHAN_6_SCL);
+      spmDataItems[ANALOG_CHAN_7_IDX].value = (double) (lsbArray[ANALOG_CHAN_7_BYTE/2] * ANALOG_CHAN_7_SCL);
+      break;
+    case SPM_ID + 3:
+      spmDataItems[ANALOG_CHAN_8_IDX].value = (double) (lsbArray[ANALOG_CHAN_8_BYTE/2] * ANALOG_CHAN_8_SCL);
+      spmDataItems[ANALOG_CHAN_9_IDX].value = (double) (lsbArray[ANALOG_CHAN_9_BYTE/2] * ANALOG_CHAN_9_SCL);
+      spmDataItems[ANALOG_CHAN_10_IDX].value = (double) (lsbArray[ANALOG_CHAN_10_BYTE/2] * ANALOG_CHAN_10_SCL);
+      spmDataItems[ANALOG_CHAN_11_IDX].value = (double) (lsbArray[ANALOG_CHAN_11_BYTE/2] * ANALOG_CHAN_11_SCL);
+      break;
+    case SPM_ID + 4:
+      spmDataItems[ANALOG_CHAN_12_IDX].value = (double) (lsbArray[ANALOG_CHAN_12_BYTE/2] * ANALOG_CHAN_12_SCL);
+      spmDataItems[ANALOG_CHAN_13_IDX].value = (double) (lsbArray[ANALOG_CHAN_13_BYTE/2] * ANALOG_CHAN_13_SCL);
+      spmDataItems[ANALOG_CHAN_14_IDX].value = (double) (lsbArray[ANALOG_CHAN_14_BYTE/2] * ANALOG_CHAN_14_SCL);
+      spmDataItems[ANALOG_CHAN_15_IDX].value = (double) (lsbArray[ANALOG_CHAN_15_BYTE/2] * ANALOG_CHAN_15_SCL);
+      break;
+    case SPM_ID + 5:
+      spmDataItems[ANALOG_CHAN_16_IDX].value = (double) (lsbArray[ANALOG_CHAN_16_BYTE/2] * ANALOG_CHAN_16_SCL);
+      spmDataItems[ANALOG_CHAN_17_IDX].value = (double) (lsbArray[ANALOG_CHAN_17_BYTE/2] * ANALOG_CHAN_17_SCL);
+      spmDataItems[ANALOG_CHAN_18_IDX].value = (double) (lsbArray[ANALOG_CHAN_18_BYTE/2] * ANALOG_CHAN_18_SCL);
+      spmDataItems[ANALOG_CHAN_19_IDX].value = (double) (lsbArray[ANALOG_CHAN_19_BYTE/2] * ANALOG_CHAN_19_SCL);
+      break;
+    case SPM_ID + 6:
+      spmDataItems[ANALOG_CHAN_20_IDX].value = (double) (lsbArray[ANALOG_CHAN_20_BYTE/2] * ANALOG_CHAN_20_SCL);
+      spmDataItems[ANALOG_CHAN_21_IDX].value = (double) (lsbArray[ANALOG_CHAN_21_BYTE/2] * ANALOG_CHAN_21_SCL);
+      spmDataItems[ANALOG_CHAN_22_IDX].value = (double) (lsbArray[ANALOG_CHAN_22_BYTE/2] * ANALOG_CHAN_22_SCL);
+      spmDataItems[ANALOG_CHAN_23_IDX].value = (double) (lsbArray[ANALOG_CHAN_23_BYTE/2] * ANALOG_CHAN_23_SCL);
+      break;
+    case SPM_ID + 7:
+      spmDataItems[ANALOG_CHAN_24_IDX].value = (double) (lsbArray[ANALOG_CHAN_24_BYTE/2] * ANALOG_CHAN_24_SCL);
+      spmDataItems[ANALOG_CHAN_25_IDX].value = (double) (lsbArray[ANALOG_CHAN_25_BYTE/2] * ANALOG_CHAN_25_SCL);
+      spmDataItems[ANALOG_CHAN_26_IDX].value = (double) (lsbArray[ANALOG_CHAN_26_BYTE/2] * ANALOG_CHAN_26_SCL);
+      spmDataItems[ANALOG_CHAN_27_IDX].value = (double) (lsbArray[ANALOG_CHAN_27_BYTE/2] * ANALOG_CHAN_27_SCL);
+      break;
+    case SPM_ID + 8:
+      spmDataItems[ANALOG_CHAN_28_IDX].value = (double) (lsbArray[ANALOG_CHAN_28_BYTE/2] * ANALOG_CHAN_28_SCL);
+      spmDataItems[ANALOG_CHAN_29_IDX].value = (double) (lsbArray[ANALOG_CHAN_29_BYTE/2] * ANALOG_CHAN_29_SCL);
+      spmDataItems[ANALOG_CHAN_30_IDX].value = (double) (lsbArray[ANALOG_CHAN_30_BYTE/2] * ANALOG_CHAN_30_SCL);
+      spmDataItems[ANALOG_CHAN_31_IDX].value = (double) (lsbArray[ANALOG_CHAN_31_BYTE/2] * ANALOG_CHAN_31_SCL);
+      break;
+    case SPM_ID + 9:
+      spmDataItems[ANALOG_CHAN_32_IDX].value = (double) (lsbArray[ANALOG_CHAN_32_BYTE/2] * ANALOG_CHAN_32_SCL);
+      spmDataItems[ANALOG_CHAN_33_IDX].value = (double) (lsbArray[ANALOG_CHAN_33_BYTE/2] * ANALOG_CHAN_33_SCL);
+      spmDataItems[ANALOG_CHAN_34_IDX].value = (double) (lsbArray[ANALOG_CHAN_34_BYTE/2] * ANALOG_CHAN_34_SCL);
+      spmDataItems[ANALOG_CHAN_35_IDX].value = (double) (lsbArray[ANALOG_CHAN_35_BYTE/2] * ANALOG_CHAN_35_SCL);
+      break;
+    case SPM_ID + 10:
+      spmDataItems[TCOUPLE_0_IDX].value = (double) ((int16_t) (lsbArray[TCOUPLE_0_BYTE/2]) * TCOUPLE_SCL);
+      spmDataItems[TCOUPLE_1_IDX].value = (double) ((int16_t) (lsbArray[TCOUPLE_1_BYTE/2]) * TCOUPLE_SCL);
+      spmDataItems[TCOUPLE_2_IDX].value = (double) ((int16_t) (lsbArray[TCOUPLE_2_BYTE/2]) * TCOUPLE_SCL);
+      spmDataItems[TCOUPLE_3_IDX].value = (double) ((int16_t) (lsbArray[TCOUPLE_3_BYTE/2]) * TCOUPLE_SCL);
+      break;
+    case SPM_ID + 11:
+      spmDataItems[TCOUPLE_4_IDX].value = (double) ((int16_t) (lsbArray[TCOUPLE_4_BYTE/2]) * TCOUPLE_SCL); 
+      spmDataItems[TCOUPLE_5_IDX].value = (double) ((int16_t) (lsbArray[TCOUPLE_5_BYTE/2]) * TCOUPLE_SCL);
+      spmDataItems[AVG_JUNCT_TEMP_IDX].value = (double) ((int16_t) (lsbArray[AVG_JUNCT_TEMP_BYTE/2]) * AVG_JUNCT_TEMP_SCL);
+      spmDataItems[TCOUPLE_1_FAULT_IDX].value = lsbArray[TCOUPLE_FAULT_BYTE] & TCOUPLE_0_FAULT_MASK;
+      spmDataItems[TCOUPLE_1_FAULT_IDX].value = lsbArray[TCOUPLE_FAULT_BYTE] & TCOUPLE_1_FAULT_MASK;
+      spmDataItems[TCOUPLE_2_FAULT_IDX].value = lsbArray[TCOUPLE_FAULT_BYTE] & TCOUPLE_2_FAULT_MASK;
+      spmDataItems[TCOUPLE_3_FAULT_IDX].value = lsbArray[TCOUPLE_FAULT_BYTE] & TCOUPLE_3_FAULT_MASK;
+      spmDataItems[TCOUPLE_4_FAULT_IDX].value = lsbArray[TCOUPLE_FAULT_BYTE] & TCOUPLE_4_FAULT_MASK;
+      spmDataItems[TCOUPLE_5_FAULT_IDX].value = lsbArray[TCOUPLE_FAULT_BYTE] & TCOUPLE_5_FAULT_MASK;
+      break;
+    case SPM_ID + 12:
+      spmDataItems[DIGITAL_INPUT_0_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_0_MASK;
+      spmDataItems[DIGITAL_INPUT_1_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_1_MASK;
+      spmDataItems[DIGITAL_INPUT_2_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_2_MASK;
+      spmDataItems[DIGITAL_INPUT_3_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_3_MASK;
+      spmDataItems[DIGITAL_INPUT_4_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_4_MASK;
+      spmDataItems[DIGITAL_INPUT_5_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_5_MASK;
+      spmDataItems[DIGITAL_INPUT_6_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_6_MASK;
+      spmDataItems[DIGITAL_INPUT_7_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_7_MASK;
+      spmDataItems[DIGITAL_INPUT_8_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_8_MASK;
+      spmDataItems[DIGITAL_INPUT_9_IDX ].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_9_MASK;
+      spmDataItems[DIGITAL_INPUT_10_IDX].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_10_MASK;
+      spmDataItems[DIGITAL_INPUT_11_IDX].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_11_MASK;
+      spmDataItems[DIGITAL_INPUT_12_IDX].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_12_MASK;
+      spmDataItems[DIGITAL_INPUT_13_IDX].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_13_MASK;
+      spmDataItems[DIGITAL_INPUT_14_IDX].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_14_MASK;
+      spmDataItems[DIGITAL_INPUT_15_IDX].value = lsbArray[DIGITAL_INPUT_BYTE] & DIGITAL_INPUT_15_MASK;
+      spmDataItems[FREQ_COUNT_0_IDX].value = (double) (lsbArray[FREQ_COUNT_0_BYTE] * FREQ_COUNT_0_SCL);
+      spmDataItems[FREQ_COUNT_1_IDX].value = (double) (lsbArray[FREQ_COUNT_0_BYTE] * FREQ_COUNT_0_SCL);
+      spmDataItems[FREQ_COUNT_2_IDX].value = (double) (lsbArray[FREQ_COUNT_0_BYTE] * FREQ_COUNT_0_SCL);
+      break;
+    case SPM_ID + 13:
+      spmDataItems[PGA_0_SETTINGS_IDX ].value = (lsbArray[PGA_SETTINGS_BYTE] & PGA_0_SETTINGS_MASK) >> PGA_0_SETTINGS_SHF;
+      spmDataItems[PGA_1_SETTINGS_IDX ].value = (lsbArray[PGA_SETTINGS_BYTE] & PGA_1_SETTINGS_MASK) >> PGA_1_SETTINGS_SHF;
+      spmDataItems[PGA_2_SETTINGS_IDX ].value = (lsbArray[PGA_SETTINGS_BYTE] & PGA_2_SETTINGS_MASK) >> PGA_2_SETTINGS_SHF;
+      spmDataItems[PGA_3_SETTINGS_IDX ].value = (lsbArray[PGA_SETTINGS_BYTE] & PGA_3_SETTINGS_MASK) >> PGA_3_SETTINGS_SHF;
+      spmDataItems[FREQ_0_SETTINGS_IDX].value = (lsbArray[FREQ_SETTINGS_BYTE] & FREQ_0_SETTINGS_MASK) >> FREQ_0_SETTINGS_SHF;
+      spmDataItems[FREQ_1_SETTINGS_IDX].value = (lsbArray[FREQ_SETTINGS_BYTE] & FREQ_1_SETTINGS_MASK) >> FREQ_1_SETTINGS_SHF;
+      spmDataItems[FREQ_2_SETTINGS_IDX].value = (lsbArray[FREQ_SETTINGS_BYTE] & FREQ_2_SETTINGS_MASK) >> FREQ_2_SETTINGS_SHF;
       break;
 
       /*Front Analog Hub*/

--- a/Wheel_Node.X/Wheel.c
+++ b/Wheel_Node.X/Wheel.c
@@ -214,24 +214,31 @@ void process_CAN_msg(CAN_message msg){
       fuelTrim.value = parseMsgMotec(&msg, FUEL_TRIM_BYTE, FUEL_TRIM_SCL);
       break;
 
-      /*Paddle Shifting ID's*/
+      /*GCM ID's*/
     case GCM_ID:
-      //paddleUptime.value = (double) ((uint16_t) msg.data[UPTIME_BYTE]);
-      //paddleTemp.value = (double) ((uint16_t) msg.data[PCB_TEMP_BYTE])*PCB_TEMP_SCL;
-      //neutQueue.value = msg.data[QUEUE_NT_BYTE] * QUEUE_NT_SCL;
-      //upQueue.value = msg.data[QUEUE_UP_BYTE] * QUEUE_UP_SCL;
-      //downQueue.value =  msg.data[QUEUE_DN_BYTE] * QUEUE_DN_SCL;
+      gcmDataItems[UPTIME_IDX].value = (uint16_t) (lsbArray[UPTIME_BYTE/2]) * UPTIME_SCL;
+      gcmDataItems[PCB_TEMP_IDX].value = (int16_t) (lsbArray[PCB_TEMP_BYTE/2]) * PCB_TEMP_SCL;
+      gcmDataItems[IC_TEMP_IDX].value = (int16_t) (lsbArray[IC_TEMP_BYTE/2]) * IC_TEMP_SCL;
       break;
     case GCM_ID + 1:
-      //gearVoltage.value = (double) ((uint16_t) msg.data[GEAR_VOLT_BYTE])*GEAR_VOLT_SCL;
-      gearPos.value = msg.data[GEAR_BYTE];
+      gcmDataItems[GEAR_IDX].value = (uint8_t) (msg.data[GEAR_BYTE]) * GEAR_SCL;
+      gcmDataItems[GEAR_VOLT_IDX].value = (uint16_t) (lsbArray[GEAR_VOLT_BYTE/2]) * GEAR_VOLT_SCL;
+      gcmDataItems[FORCE_IDX].value = (int16_t) (lsbArray[FORCE_BYTE/2]) * FORCE_SCL;
+      break;
+    case GCM_ID + 2:
+      gcmDataItems[PADDLE_UP_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & PADDLE_UP_GCM_SW_BIT;
+      gcmDataItems[PADDLE_DOWN_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & PADDLE_DOWN_GCM_SW_BIT;
+      gcmDataItems[NEUTRAL_SW_IDX].value = msg.data[GCM_SWITCH_BYTE] & NEUTRAL_GCM_SW_BIT;
+      gcmDataItems[QUEUE_UP_IDX].value = (uint8_t) (msg.data[QUEUE_UP_BYTE]) * QUEUE_UP_SCL;
+      gcmDataItems[QUEUE_DN_IDX].value = (uint8_t) (msg.data[QUEUE_DN_BYTE]) * QUEUE_DN_SCL;
+      gcmDataItems[QUEUE_NT_IDX].value = (uint8_t) (msg.data[QUEUE_NT_BYTE]) * QUEUE_NT_SCL;
       break;
 
       /*PDM ID's*/
     case PDM_ID:
-      pdmDataItems[UPTIME_IDX].value = (uint16_t) (msg.data[PDM_UPTIME_BYTE]) * PDM_UPTIME_SCL;
-      pdmDataItems[PCB_TEMP_IDX].value = (int16_t) (msg.data[PDM_PCB_TEMP_BYTE]) * PDM_PCB_TEMP_SCL;
-      pdmDataItems[IC_TEMP_IDX].value = (int16_t) (msg.data[PDM_IC_TEMP_BYTE]) * PDM_IC_TEMP_SCL;
+      pdmDataItems[UPTIME_IDX].value = (uint16_t) (lsbArray[UPTIME_BYTE/2]) * UPTIME_SCL;
+      pdmDataItems[PCB_TEMP_IDX].value = (int16_t) (lsbArray[PCB_TEMP_BYTE/2]) * PCB_TEMP_SCL;
+      pdmDataItems[IC_TEMP_IDX].value = (int16_t) (lsbArray[IC_TEMP_BYTE/2]) * IC_TEMP_SCL;
       break;
     case PDM_ID + 1:
 

--- a/Wheel_Node.X/Wheel.c
+++ b/Wheel_Node.X/Wheel.c
@@ -229,121 +229,121 @@ void process_CAN_msg(CAN_message msg){
 
       /*PDM ID's*/
     case PDM_ID:
-      pdmUptime.value = (uint16_t) (msg.data[PDM_UPTIME_BYTE]) * PDM_UPTIME_SCL;
-      pdmTemp.value = (int16_t) (msg.data[PDM_PCB_TEMP_BYTE]) * PDM_PCB_TEMP_SCL;
-      pdmICTemp.value = (int16_t) (msg.data[PDM_IC_TEMP_BYTE]) * PDM_IC_TEMP_SCL;
+      pdmDataItems[UPTIME_IDX].value = (uint16_t) (msg.data[PDM_UPTIME_BYTE]) * PDM_UPTIME_SCL;
+      pdmDataItems[PCB_TEMP_IDX].value = (int16_t) (msg.data[PDM_PCB_TEMP_BYTE]) * PDM_PCB_TEMP_SCL;
+      pdmDataItems[IC_TEMP_IDX].value = (int16_t) (msg.data[PDM_IC_TEMP_BYTE]) * PDM_IC_TEMP_SCL;
       break;
     case PDM_ID + 1:
 
       // Enablity
-      STRenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & STR_ENBL_BIT;
-      BVBATenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & BVBAT_ENBL_BIT;
-      AUXenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & AUX_ENBL_BIT;
-      ECUenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & ECU_ENBL_BIT;
-      WTRenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & WTR_ENBL_BIT;
-      FANenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & FAN_ENBL_BIT;
-      PDLDenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLD_ENBL_BIT;
-      PDLUenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLU_ENBL_BIT;
-      ABSenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & ABS_ENBL_BIT;
-      INJenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & INJ_ENBL_BIT;
-      IGNenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & IGN_ENBL_BIT;
-      FUELenabl.value = lsbArray[LOAD_ENABLITY_BYTE/2] & FUEL_ENBL_BIT;
+      pdmDataItems[STR_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & STR_ENBL_BIT;
+      pdmDataItems[BVBAT_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & BVBAT_ENBL_BIT;
+      pdmDataItems[AUX_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & AUX_ENBL_BIT;
+      pdmDataItems[ECU_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & ECU_ENBL_BIT;
+      pdmDataItems[WTR_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & WTR_ENBL_BIT;
+      pdmDataItems[FAN_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & FAN_ENBL_BIT;
+      pdmDataItems[PDLD_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLD_ENBL_BIT;
+      pdmDataItems[PDLU_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & PDLU_ENBL_BIT;
+      pdmDataItems[ABS_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & ABS_ENBL_BIT;
+      pdmDataItems[INJ_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & INJ_ENBL_BIT;
+      pdmDataItems[IGN_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & IGN_ENBL_BIT;
+      pdmDataItems[FUEL_ENABLITY_IDX].value = lsbArray[LOAD_ENABLITY_BYTE/2] & FUEL_ENBL_BIT;
 
       // Peak Mode
-      STRpm.value = lsbArray[LOAD_PEAK_BYTE/2] & STR_PEAKM_BIT;
-      BVBATpm.value = lsbArray[LOAD_PEAK_BYTE/2] & BVBAT_PEAKM_BIT;
-      AUXpm.value = lsbArray[LOAD_PEAK_BYTE/2] & AUX_PEAKM_BIT;
-      ECUpm.value = lsbArray[LOAD_PEAK_BYTE/2] & ECU_PEAKM_BIT;
-      WTRpm.value = lsbArray[LOAD_PEAK_BYTE/2] & WTR_PEAKM_BIT;
-      FANpm.value = lsbArray[LOAD_PEAK_BYTE/2] & FAN_PEAKM_BIT;
-      PDLDpm.value = lsbArray[LOAD_PEAK_BYTE/2] & PDLD_PEAKM_BIT;
-      PDLUpm.value = lsbArray[LOAD_PEAK_BYTE/2] & PDLU_PEAKM_BIT;
-      ABSpm.value = lsbArray[LOAD_PEAK_BYTE/2] & ABS_PEAKM_BIT;
-      INJpm.value = lsbArray[LOAD_PEAK_BYTE/2] & INJ_PEAKM_BIT;
-      IGNpm.value = lsbArray[LOAD_PEAK_BYTE/2] & IGN_PEAKM_BIT;
-      FUELpm.value = lsbArray[LOAD_PEAK_BYTE/2] & FUEL_PEAKM_BIT;
+      pdmDataItems[STR_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & STR_PEAKM_BIT;
+      pdmDataItems[BVBAT_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & BVBAT_PEAKM_BIT;
+      pdmDataItems[AUX_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & AUX_PEAKM_BIT;
+      pdmDataItems[ECU_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & ECU_PEAKM_BIT;
+      pdmDataItems[WTR_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & WTR_PEAKM_BIT;
+      pdmDataItems[FAN_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & FAN_PEAKM_BIT;
+      pdmDataItems[PDLD_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & PDLD_PEAKM_BIT;
+      pdmDataItems[PDLU_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & PDLU_PEAKM_BIT;
+      pdmDataItems[ABS_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & ABS_PEAKM_BIT;
+      pdmDataItems[INJ_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & INJ_PEAKM_BIT;
+      pdmDataItems[IGN_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & IGN_PEAKM_BIT;
+      pdmDataItems[FUEL_PEAK_MODE_IDX].value = lsbArray[LOAD_PEAK_BYTE/2] & FUEL_PEAKM_BIT;
 
       // Total current
-      pdmTOTdraw.value = (uint16_t) (lsbArray[TOTAL_CURRENT_BYTE/2]) * TOTAL_CURRENT_SCL;
+      pdmDataItems[TOTAL_CURRENT_IDX].value = (uint16_t) (lsbArray[TOTAL_CURRENT_BYTE/2]) * TOTAL_CURRENT_SCL;
 
       // Switch bitmap
-      AUX2pdmSw.value = msg.data[PDM_SWITCH_BYTE] & AUX2_PDM_SW_BIT;
-      AUX1pdmSw.value = msg.data[PDM_SWITCH_BYTE] & AUX1_PDM_SW_BIT;
-      ABSpdmSw.value = msg.data[PDM_SWITCH_BYTE] & ABS_PDM_SW_BIT;
-      KILLpdmSw.value = msg.data[PDM_SWITCH_BYTE] & KILL_PDM_SW_BIT;
-      ACT_DNpdmSw.value = msg.data[PDM_SWITCH_BYTE] & ACT_DN_PDM_SW_BIT;
-      ACT_UPpdmSw.value = msg.data[PDM_SWITCH_BYTE] & ACT_UP_PDM_SW_BIT;
-      ONpdmSw.value = msg.data[PDM_SWITCH_BYTE] & ON_PDM_SW_BIT;
-      STRpdmSw.value = msg.data[PDM_SWITCH_BYTE] & STR_PDM_SW_BIT;
+      pdmDataItems[AUX2_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & AUX2_PDM_SW_BIT;
+      pdmDataItems[AUX1_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & AUX1_PDM_SW_BIT;
+      pdmDataItems[ABS_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ABS_PDM_SW_BIT;
+      pdmDataItems[KILL_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & KILL_PDM_SW_BIT;
+      pdmDataItems[ACT_DN_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ACT_DN_PDM_SW_BIT;
+      pdmDataItems[ACT_UP_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ACT_UP_PDM_SW_BIT;
+      pdmDataItems[ON_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & ON_PDM_SW_BIT;
+      pdmDataItems[STR_SWITCH_IDX].value = msg.data[PDM_SWITCH_BYTE] & STR_PDM_SW_BIT;
 
       // Flags
-      KillEngineFlag.value = msg.data[PDM_FLAG_BYTE] & KILL_ENGINE_PDM_FLAG_BIT;
-      KillCarFlag.value = msg.data[PDM_FLAG_BYTE] & KILL_CAR_PDM_FLAG_BIT;
-      OverTempFlag.value = msg.data[PDM_FLAG_BYTE] & OVER_TEMP_PDM_FLAG_BIT;
-      FuelPrimeFlag.value = msg.data[PDM_FLAG_BYTE] & FUEL_PRIME_PDM_FLAG_BIT;
+      pdmDataItems[KILL_ENGINE_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & KILL_ENGINE_PDM_FLAG_BIT;
+      pdmDataItems[KILL_CAR_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & KILL_CAR_PDM_FLAG_BIT;
+      pdmDataItems[OVER_TEMP_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & OVER_TEMP_PDM_FLAG_BIT;
+      pdmDataItems[FUEL_PRIME_FLAG_IDX].value = msg.data[PDM_FLAG_BYTE] & FUEL_PRIME_PDM_FLAG_BIT;
       break;
     case PDM_ID + 2:
-      pdmVBat.value = (uint16_t) (lsbArray[VBAT_RAIL_BYTE/2]) * VBAT_RAIL_SCL;
-      pdm12v.value = (uint16_t) (lsbArray[V12_RAIL_BYTE/2]) * V12_RAIL_SCL;
-      pdm5v.value = (uint16_t) (lsbArray[V5_RAIL_BYTE/2]) * V5_RAIL_SCL;
-      pdm3v3.value = (uint16_t) (lsbArray[V3V3_RAIL_BYTE/2]) * V3V3_RAIL_SCL;
+      pdmDataItems[VBAT_RAIL_IDX].value = (uint16_t) (lsbArray[VBAT_RAIL_BYTE/2]) * VBAT_RAIL_SCL;
+      pdmDataItems[V12_RAIL_IDX].value = (uint16_t) (lsbArray[V12_RAIL_BYTE/2]) * V12_RAIL_SCL;
+      pdmDataItems[V5_RAIL_IDX].value = (uint16_t) (lsbArray[V5_RAIL_BYTE/2]) * V5_RAIL_SCL;
+      pdmDataItems[V3V3_RAIL_IDX].value = (uint16_t) (lsbArray[V3V3_RAIL_BYTE/2]) * V3V3_RAIL_SCL;
       break;
     case PDM_ID + 3:
-      pdmFUELdraw.value = (uint16_t) (lsbArray[FUEL_DRAW_BYTE/2]) * FUEL_DRAW_SCL;
-      pdmIGNdraw.value = (uint16_t) (lsbArray[IGN_DRAW_BYTE/2]) * IGN_DRAW_SCL;
-      pdmINJdraw.value = (uint16_t) (lsbArray[INJ_DRAW_BYTE/2]) * INJ_DRAW_SCL;
-      pdmABSdraw.value = (uint16_t) (lsbArray[ABS_DRAW_BYTE/2]) * ABS_DRAW_SCL;
+      pdmDataItems[FUEL_DRAW_IDX].value = (uint16_t) (lsbArray[FUEL_DRAW_BYTE/2]) * FUEL_DRAW_SCL;
+      pdmDataItems[IGN_DRAW_IDX].value = (uint16_t) (lsbArray[IGN_DRAW_BYTE/2]) * IGN_DRAW_SCL;
+      pdmDataItems[INJ_DRAW_IDX].value = (uint16_t) (lsbArray[INJ_DRAW_BYTE/2]) * INJ_DRAW_SCL;
+      pdmDataItems[ABS_DRAW_IDX].value = (uint16_t) (lsbArray[ABS_DRAW_BYTE/2]) * ABS_DRAW_SCL;
       break;
     case PDM_ID + 4:
-      pdmPDLUdraw.value = (uint16_t) (lsbArray[PDLU_DRAW_BYTE/2]) * PDLU_DRAW_SCL;
-      pdmPDLDdraw.value = (uint16_t) (lsbArray[PDLD_DRAW_BYTE/2]) * PDLD_DRAW_SCL;
-      pdmFANdraw.value = (uint16_t) (lsbArray[FAN_DRAW_BYTE/2]) * FAN_DRAW_SCL;
-      pdmWTRdraw.value = (uint16_t) (lsbArray[WTR_DRAW_BYTE/2]) * WTR_DRAW_SCL;
+      pdmDataItems[PDLU_DRAW_IDX].value = (uint16_t) (lsbArray[PDLU_DRAW_BYTE/2]) * PDLU_DRAW_SCL;
+      pdmDataItems[PDLD_DRAW_IDX].value = (uint16_t) (lsbArray[PDLD_DRAW_BYTE/2]) * PDLD_DRAW_SCL;
+      pdmDataItems[FAN_DRAW_IDX].value = (uint16_t) (lsbArray[FAN_DRAW_BYTE/2]) * FAN_DRAW_SCL;
+      pdmDataItems[WTR_DRAW_IDX].value = (uint16_t) (lsbArray[WTR_DRAW_BYTE/2]) * WTR_DRAW_SCL;
       break;
     case PDM_ID + 5:
-      pdmECUdraw.value = (uint16_t) (lsbArray[ECU_DRAW_BYTE/2]) * ECU_DRAW_SCL;
-      pdmAUXdraw.value = (uint16_t) (lsbArray[AUX_DRAW_BYTE/2]) * AUX_DRAW_SCL;
-      pdmBVBATdraw.value = (uint16_t) (lsbArray[BVBAT_DRAW_BYTE/2]) * BVBAT_DRAW_SCL;
-      pdmSTRdraw.value = (uint16_t) (lsbArray[STR_DRAW_BYTE/2]) * STR_DRAW_SCL;
+      pdmDataItems[ECU_DRAW_IDX].value = (uint16_t) (lsbArray[ECU_DRAW_BYTE/2]) * ECU_DRAW_SCL;
+      pdmDataItems[AUX_DRAW_IDX].value = (uint16_t) (lsbArray[AUX_DRAW_BYTE/2]) * AUX_DRAW_SCL;
+      pdmDataItems[BVBAT_DRAW_IDX].value = (uint16_t) (lsbArray[BVBAT_DRAW_BYTE/2]) * BVBAT_DRAW_SCL;
+      pdmDataItems[STR_DRAW_IDX].value = (uint16_t) (lsbArray[STR_DRAW_BYTE/2]) * STR_DRAW_SCL;
       break;
     case PDM_ID + 6:
-      pdmFUELcut.value = (uint16_t) (lsbArray[FUEL_CUT_BYTE/2]) * FUEL_CUT_SCL;
-      pdmIGNcut.value = (uint16_t) (lsbArray[IGN_CUT_BYTE/2]) * IGN_CUT_SCL;
-      pdmINJcut.value = (uint16_t) (lsbArray[INJ_CUT_BYTE/2]) * INJ_CUT_SCL;
-      pdmABScut.value = (uint16_t) (lsbArray[ABS_CUT_BYTE/2]) * ABS_CUT_SCL;
+      pdmDataItems[FUEL_CUT_IDX].value = (uint16_t) (lsbArray[FUEL_CUT_BYTE/2]) * FUEL_CUT_SCL;
+      pdmDataItems[IGN_CUT_IDX].value = (uint16_t) (lsbArray[IGN_CUT_BYTE/2]) * IGN_CUT_SCL;
+      pdmDataItems[INJ_CUT_IDX].value = (uint16_t) (lsbArray[INJ_CUT_BYTE/2]) * INJ_CUT_SCL;
+      pdmDataItems[ABS_CUT_IDX].value = (uint16_t) (lsbArray[ABS_CUT_BYTE/2]) * ABS_CUT_SCL;
       break;
     case PDM_ID + 7:
-      pdmPDLUcut.value = (uint16_t) (lsbArray[PDLU_CUT_BYTE/2]) * PDLU_CUT_SCL;
-      pdmPDLDcut.value = (uint16_t) (lsbArray[PDLD_CUT_BYTE/2]) * PDLD_CUT_SCL;
-      pdmFANcut.value = (uint16_t) (lsbArray[FAN_CUT_BYTE/2]) * FAN_CUT_SCL;
-      pdmWTRcut.value = (uint16_t) (lsbArray[WTR_CUT_BYTE/2]) * WTR_CUT_SCL;
+      pdmDataItems[PDLU_CUT_IDX].value = (uint16_t) (lsbArray[PDLU_CUT_BYTE/2]) * PDLU_CUT_SCL;
+      pdmDataItems[PDLD_CUT_IDX].value = (uint16_t) (lsbArray[PDLD_CUT_BYTE/2]) * PDLD_CUT_SCL;
+      pdmDataItems[FAN_CUT_IDX].value = (uint16_t) (lsbArray[FAN_CUT_BYTE/2]) * FAN_CUT_SCL;
+      pdmDataItems[WTR_CUT_IDX].value = (uint16_t) (lsbArray[WTR_CUT_BYTE/2]) * WTR_CUT_SCL;
       break;
     case PDM_ID + 8:
-      pdmECUcut.value = (uint16_t) (lsbArray[ECU_CUT_BYTE/2]) * ECU_CUT_SCL;
-      pdmAUXcut.value = (uint16_t) (lsbArray[AUX_CUT_BYTE/2]) * AUX_CUT_SCL;
-      pdmBVBATcut.value = (uint16_t) (lsbArray[BVBAT_CUT_BYTE/2]) * BVBAT_CUT_SCL;
+      pdmDataItems[ECU_CUT_IDX].value = (uint16_t) (lsbArray[ECU_CUT_BYTE/2]) * ECU_CUT_SCL;
+      pdmDataItems[AUX_CUT_IDX].value = (uint16_t) (lsbArray[AUX_CUT_BYTE/2]) * AUX_CUT_SCL;
+      pdmDataItems[BVBAT_CUT_IDX].value = (uint16_t) (lsbArray[BVBAT_CUT_BYTE/2]) * BVBAT_CUT_SCL;
       break;
     case PDM_ID + 9:
-      pdmFUELPcut.value = (uint16_t) (lsbArray[FUEL_CUT_P_BYTE/2]) * FUEL_CUT_P_SCL;
-      pdmFANPcut.value = (uint16_t) (lsbArray[FAN_CUT_P_BYTE/2]) * FAN_CUT_P_SCL;
-      pdmWTRPcut.value = (uint16_t) (lsbArray[WTR_CUT_P_BYTE/2]) * WTR_CUT_P_SCL;
-      pdmECUPcut.value = (uint16_t) (lsbArray[ECU_CUT_P_BYTE/2]) * ECU_CUT_P_SCL;
+      pdmDataItems[FUEL_CUT_P_IDX].value = (uint16_t) (lsbArray[FUEL_CUT_P_BYTE/2]) * FUEL_CUT_P_SCL;
+      pdmDataItems[FAN_CUT_P_IDX].value = (uint16_t) (lsbArray[FAN_CUT_P_BYTE/2]) * FAN_CUT_P_SCL;
+      pdmDataItems[WTR_CUT_P_IDX].value = (uint16_t) (lsbArray[WTR_CUT_P_BYTE/2]) * WTR_CUT_P_SCL;
+      pdmDataItems[ECU_CUT_P_IDX].value = (uint16_t) (lsbArray[ECU_CUT_P_BYTE/2]) * ECU_CUT_P_SCL;
       break;
     case PDM_ID + 10:
-      FUELOCCount.value = (uint16_t) (msg.data[FUEL_OC_COUNT_BYTE]);
-      IGNOCCount.value = (uint16_t) (msg.data[IGN_OC_COUNT_BYTE]);
-      INJOCCount.value = (uint16_t) (msg.data[INJ_OC_COUNT_BYTE]);
-      ABSOCCount.value = (uint16_t) (msg.data[ABS_OC_COUNT_BYTE]);
-      PDLUOCCount.value = (uint16_t) (msg.data[PDLU_OC_COUNT_BYTE]);
-      PDLDOCCount.value = (uint16_t) (msg.data[PDLD_OC_COUNT_BYTE]);
-      FANOCCount.value = (uint16_t) (msg.data[FAN_OC_COUNT_BYTE]);
-      WTROCCount.value = (uint16_t) (msg.data[WTR_OC_COUNT_BYTE]);
+      pdmDataItems[FUEL_OC_COUNT_IDX].value = (uint16_t) (msg.data[FUEL_OC_COUNT_BYTE]);
+      pdmDataItems[IGN_OC_COUNT_IDX].value = (uint16_t) (msg.data[IGN_OC_COUNT_BYTE]);
+      pdmDataItems[INJ_OC_COUNT_IDX].value = (uint16_t) (msg.data[INJ_OC_COUNT_BYTE]);
+      pdmDataItems[ABS_OC_COUNT_IDX].value = (uint16_t) (msg.data[ABS_OC_COUNT_BYTE]);
+      pdmDataItems[PDLU_OC_COUNT_IDX].value = (uint16_t) (msg.data[PDLU_OC_COUNT_BYTE]);
+      pdmDataItems[PDLD_OC_COUNT_IDX].value = (uint16_t) (msg.data[PDLD_OC_COUNT_BYTE]);
+      pdmDataItems[FAN_OC_COUNT_IDX].value = (uint16_t) (msg.data[FAN_OC_COUNT_BYTE]);
+      pdmDataItems[WTR_OC_COUNT_IDX].value = (uint16_t) (msg.data[WTR_OC_COUNT_BYTE]);
       break;
     case PDM_ID + 11:
-      ECUOCCount.value = (uint16_t) (msg.data[ECU_OC_COUNT_BYTE]);
-      AUXOCCount.value = (uint16_t) (msg.data[AUX_OC_COUNT_BYTE]);
-      BVBATOCCount.value = (uint16_t) (msg.data[BVBAT_OC_COUNT_BYTE]);
-      STROCCount.value = (uint16_t) (msg.data[STR_OC_COUNT_BYTE]);
+      pdmDataItems[ECU_OC_COUNT_IDX].value = (uint16_t) (msg.data[ECU_OC_COUNT_BYTE]);
+      pdmDataItems[AUX_OC_COUNT_IDX].value = (uint16_t) (msg.data[AUX_OC_COUNT_BYTE]);
+      pdmDataItems[BVBAT_OC_COUNT_IDX].value = (uint16_t) (msg.data[BVBAT_OC_COUNT_BYTE]);
+      pdmDataItems[STR_OC_COUNT_IDX].value = (uint16_t) (msg.data[STR_OC_COUNT_BYTE]);
       break;
       /*Tire Temps*/
     case TIRE_TEMP_FL_ID:

--- a/Wheel_Node.X/Wheel.c
+++ b/Wheel_Node.X/Wheel.c
@@ -172,46 +172,47 @@ void process_CAN_msg(CAN_message msg){
 
     /*Motec Paddle Shifting*/
     case MOTEC_ID + 0:
-      rpm.value = parseMsgMotec(&msg, ENG_RPM_BYTE, ENG_RPM_SCL);
-      throtPos.value = parseMsgMotec(&msg, THROTTLE_POS_BYTE, THROTTLE_POS_SCL);
-      lambda.value = parseMsgMotec(&msg, LAMBDA_BYTE, LAMBDA_SCL);
-      batVoltage.value = parseMsgMotec(&msg, VOLT_ECU_BYTE, VOLT_ECU_SCL);
+      motecDataItems[ENG_RPM_IDX].value = parseMsgMotec(&msg, ENG_RPM_BYTE, ENG_RPM_SCL);
+      motecDataItems[THROTTLE_POS_IDX].value = parseMsgMotec(&msg, THROTTLE_POS_BYTE, THROTTLE_POS_SCL);
+      motecDataItems[LAMBDA_IDX].value = parseMsgMotec(&msg, LAMBDA_BYTE, LAMBDA_SCL);
+      motecDataItems[VOLT_ECU_IDX].value = parseMsgMotec(&msg, VOLT_ECU_BYTE, VOLT_ECU_SCL);
       break;
     case MOTEC_ID + 1:
-      waterTemp.value = parseMsgMotec(&msg, ENG_TEMP_BYTE, ENG_TEMP_SCL);
-      oilTemp.value = parseMsgMotec(&msg, OIL_TEMP_BYTE, OIL_TEMP_SCL);
-      manifoldTemp.value = parseMsgMotec(&msg, MANIFOLD_TEMP_BYTE, MANIFOLD_TEMP_SCL);
-      fuelTemp.value = parseMsgMotec(&msg, FUEL_TEMP_BYTE, FUEL_TEMP_SCL);
+      motecDataItems[ENG_TEMP_IDX].value = parseMsgMotec(&msg, ENG_TEMP_BYTE, ENG_TEMP_SCL);
+      motecDataItems[OIL_TEMP_IDX].value = parseMsgMotec(&msg, OIL_TEMP_BYTE, OIL_TEMP_SCL);
+      motecDataItems[MANIFOLD_TEMP_IDX].value = parseMsgMotec(&msg, MANIFOLD_TEMP_BYTE, MANIFOLD_TEMP_SCL);
+      motecDataItems[FUEL_TEMP_IDX].value = parseMsgMotec(&msg, FUEL_TEMP_BYTE, FUEL_TEMP_SCL);
       break;
     case MOTEC_ID + 2:
-      ambientPress.value = parseMsgMotec(&msg, AMBIENT_PRES_BYTE, AMBIENT_PRES_SCL);
-      oilPress.value = parseMsgMotec(&msg, OIL_PRES_BYTE, OIL_PRES_SCL);
-      manifoldPress.value = parseMsgMotec(&msg, MANIFOLD_TEMP_BYTE, MANIFOLD_TEMP_SCL);
-      fuelPress.value = parseMsgMotec(&msg, FUEL_PRES_BYTE, FUEL_PRES_SCL);
+      motecDataItems[AMBIENT_PRES_IDX].value = parseMsgMotec(&msg, AMBIENT_PRES_BYTE, AMBIENT_PRES_SCL);
+      motecDataItems[OIL_PRES_IDX].value = parseMsgMotec(&msg, OIL_PRES_BYTE, OIL_PRES_SCL);
+      motecDataItems[MANIFOLD_PRES_IDX].value = parseMsgMotec(&msg, MANIFOLD_TEMP_BYTE, MANIFOLD_TEMP_SCL);
+      motecDataItems[FUEL_PRES_IDX].value = parseMsgMotec(&msg, FUEL_PRES_BYTE, FUEL_PRES_SCL);
       break;
     case MOTEC_ID + 3:
-      wheelSpeedFL.value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
-      wheelSpeedFR.value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
-      wheelSpeedRL.value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
-      wheelSpeedRR.value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
+      motecDataItems[WHEELSPEED_FL_IDX].value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
+      motecDataItems[WHEELSPEED_FR_IDX].value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
+      motecDataItems[WHEELSPEED_RL_IDX].value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
+      motecDataItems[WHEELSPEED_RR_IDX].value = parseMsgMotec(&msg, WHEELSPEED_FL_BYTE, WHEELSPEED_FL_SCL);
       break;
     case MOTEC_ID + 4:
-      driveSpeed.value = parseMsgMotec(&msg, DRIVE_SPEED_BYTE, DRIVE_SPEED_SCL);
-      groundSpeed.value = parseMsgMotec(&msg, GROUND_SPEED_BYTE, GROUND_SPEED_SCL);
-      gpsSpeed.value = parseMsgMotec(&msg, GPS_SPEED_BYTE, GPS_SPEED_SCL);
-      gpsAltitude.value = parseMsgMotec(&msg, GPS_ALT_BYTE, GPS_ALT_SCL);
+      motecDataItems[DRIVE_SPEED_IDX].value = parseMsgMotec(&msg, DRIVE_SPEED_BYTE, DRIVE_SPEED_SCL);
+      motecDataItems[GROUND_SPEED_IDX].value = parseMsgMotec(&msg, GROUND_SPEED_BYTE, GROUND_SPEED_SCL);
+      motecDataItems[GPS_SPEED_IDX].value = parseMsgMotec(&msg, GPS_SPEED_BYTE, GPS_SPEED_SCL);
+      motecDataItems[GPS_ALT_IDX].value = parseMsgMotec(&msg, GPS_ALT_BYTE, GPS_ALT_SCL);
       break;
     case MOTEC_ID + 5:
       break;
     case MOTEC_ID + 6:
-      gpsTime.value = (double) ((msg.data[GPS_TIME_BYTE] << 24)|(msg.data[GPS_TIME_BYTE+1] << 16)
-          |(msg.data[GPS_TIME_BYTE+2] << 8)|msg.data[GPS_TIME_BYTE+3]) * GPS_TIME_SCL;
-      runTime.value = parseMsgMotec(&msg, RUN_TIME_BYTE, RUN_TIME_SCL);
-      fuelConsum.value = parseMsgMotec(&msg, FUEL_USED_BYTE, FUEL_USED_SCL);
+      motecDataItems[GPS_TIME_IDX].value = (double) ((msg.data[GPS_TIME_BYTE] << 24)|(msg.data[GPS_TIME_BYTE+1] << 16) |(msg.data[GPS_TIME_BYTE+2] << 8)|msg.data[GPS_TIME_BYTE+3]) * GPS_TIME_SCL;
+      motecDataItems[RUN_TIME_IDX].value = parseMsgMotec(&msg, RUN_TIME_BYTE, RUN_TIME_SCL);
+      motecDataItems[FUEL_USED_IDX].value = parseMsgMotec(&msg, FUEL_USED_BYTE, FUEL_USED_SCL);
       break;
     case MOTEC_ID + 7:
-      fuelInjDuty.value = parseMsgMotec(&msg, FUEL_INJ_DUTY_BYTE, FUEL_INJ_DUTY_SCL);
-      fuelTrim.value = parseMsgMotec(&msg, FUEL_TRIM_BYTE, FUEL_TRIM_SCL);
+      motecDataItems[FUEL_INJ_DUTY_IDX].value = parseMsgMotec(&msg, FUEL_INJ_DUTY_BYTE, FUEL_INJ_DUTY_SCL);
+      motecDataItems[FUEL_TRIM_IDX].value = parseMsgMotec(&msg, FUEL_TRIM_BYTE, FUEL_TRIM_SCL);
+      motecDataItems[SHIFT_FORCE_IDX].value = parseMsgMotec(&msg, SHIFT_FORCE_BYTE, SHIFT_FORCE_SCL);
+      motecDataItems[AIR_TEMP_IDX].value = parseMsgMotec(&msg, AIR_TEMP_BYTE, AIR_TEMP_SCL);
       break;
 
       /*GCM ID's*/

--- a/Wheel_Node.X/Wheel.c
+++ b/Wheel_Node.X/Wheel.c
@@ -353,31 +353,36 @@ void process_CAN_msg(CAN_message msg){
       pdmDataItems[BVBAT_OC_COUNT_IDX].value = (uint16_t) (msg.data[BVBAT_OC_COUNT_BYTE]);
       pdmDataItems[STR_OC_COUNT_IDX].value = (uint16_t) (msg.data[STR_OC_COUNT_BYTE]);
       break;
+
       /*Tire Temps*/
     case TIRE_TEMP_FL_ID:
-      ttFLA[0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      ttFLA[1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      ttFLA[2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      ttFLA[3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
-      ttFL.value = (ttFLA[0].value+ttFLA[1].value+ttFLA[2].value+ttFLA[3].value)/4.0;
+      tireTempDataItems[FL0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FL1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FL2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FL3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FL].value = (tireTempDataItems[FL0].value + tireTempDataItems[FL1].value + tireTempDataItems[FL2].value + tireTempDataItems[FL3].value)/4.0;
+      break;
     case TIRE_TEMP_FR_ID:
-      ttFRA[0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      ttFRA[1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      ttFRA[2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      ttFRA[3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
-      ttFR.value = (ttFRA[0].value+ttFRA[1].value+ttFRA[2].value+ttFRA[3].value)/4.0;
+      tireTempDataItems[FR0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FR1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FR2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FR3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[FR].value = (tireTempDataItems[FR0].value + tireTempDataItems[FR1].value + tireTempDataItems[FR2].value + tireTempDataItems[FR3].value)/4.0;
+      break;
     case TIRE_TEMP_RL_ID:
-      ttRLA[0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      ttRLA[1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      ttRLA[2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      ttRLA[3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
-      ttRL.value = (ttRLA[0].value+ttRLA[1].value+ttRLA[2].value+ttRLA[3].value)/4.0;
+      tireTempDataItems[RL0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RL1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RL2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RL3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RL].value = (tireTempDataItems[RL0].value + tireTempDataItems[RL1].value + tireTempDataItems[RL2].value + tireTempDataItems[RL3].value)/4.0;
+      break;
     case TIRE_TEMP_RR_ID:
-      ttRRA[0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
-      ttRRA[1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
-      ttRRA[2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
-      ttRRA[3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
-      ttRR.value = (ttRRA[0].value+ttRRA[1].value+ttRRA[2].value+ttRRA[3].value)/4.0;
+      tireTempDataItems[RR0].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_1_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RR1].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_2_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RR2].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_3_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RR3].value = (double) ((uint16_t) (msg.data[TIRE_TEMP_4_BYTE])*TIRE_TEMP_SCL);
+      tireTempDataItems[RR].value = (tireTempDataItems[RR0].value + tireTempDataItems[RR1].value + tireTempDataItems[RR2].value + tireTempDataItems[RR3].value)/4.0;
+      break;
 
       /*Front Analog Hub*/
     case ANALOG_FRONT_ID + 1:

--- a/Wheel_Node.X/Wheel.h
+++ b/Wheel_Node.X/Wheel.h
@@ -80,51 +80,6 @@
 #define CAN_SW_ADL_FREQ   500
 #define CAN_DIAG_FREQ     1000
 
-//PDM Bitmask bits
-#define STR_ENBL_BIT   0x10
-#define BVBAT_ENBL_BIT 0x20
-#define AUX_ENBL_BIT   0x40
-#define ECU_ENBL_BIT   0x80
-#define WTR_ENBL_BIT   0x100
-#define FAN_ENBL_BIT   0x200
-#define PDLD_ENBL_BIT  0x400
-#define PDLU_ENBL_BIT  0x800
-#define ABS_ENBL_BIT   0x1000
-#define INJ_ENBL_BIT   0x2000
-#define IGN_ENBL_BIT   0x4000
-#define FUEL_ENBL_BIT  0x8000
-
-#define STR_PEAKM_BIT   0x10
-#define BVBAT_PEAKM_BIT 0x20
-#define AUX_PEAKM_BIT   0x40
-#define ECU_PEAKM_BIT   0x80
-#define WTR_PEAKM_BIT   0x100
-#define FAN_PEAKM_BIT   0x200
-#define PDLD_PEAKM_BIT  0x400
-#define PDLU_PEAKM_BIT  0x800
-#define ABS_PEAKM_BIT   0x1000
-#define INJ_PEAKM_BIT   0x2000
-#define IGN_PEAKM_BIT   0x4000
-#define FUEL_PEAKM_BIT  0x8000
-
-#define AUX2_PDM_SW_BIT   0x1
-#define AUX1_PDM_SW_BIT   0x2
-#define ABS_PDM_SW_BIT    0x4
-#define KILL_PDM_SW_BIT   0x8
-#define ACT_DN_PDM_SW_BIT 0x10
-#define ACT_UP_PDM_SW_BIT 0x20
-#define ON_PDM_SW_BIT     0x40
-#define STR_PDM_SW_BIT    0x80
-
-#define KILL_ENGINE_PDM_FLAG_BIT  0x10
-#define KILL_CAR_PDM_FLAG_BIT     0x20
-#define OVER_TEMP_PDM_FLAG_BIT    0x40
-#define FUEL_PRIME_PDM_FLAG_BIT   0x80
-
-#define PADDLE_UP_GCM_SW_BIT      0x1
-#define PADDLE_DOWN_GCM_SW_BIT    0x2
-#define NEUTRAL_GCM_SW_BIT        0x4
-
 volatile uint32_t millis;
 
 void main(void);

--- a/Wheel_Node.X/Wheel.h
+++ b/Wheel_Node.X/Wheel.h
@@ -121,6 +121,10 @@
 #define OVER_TEMP_PDM_FLAG_BIT    0x40
 #define FUEL_PRIME_PDM_FLAG_BIT   0x80
 
+#define PADDLE_UP_GCM_SW_BIT      0x1
+#define PADDLE_DOWN_GCM_SW_BIT    0x2
+#define NEUTRAL_GCM_SW_BIT        0x4
+
 volatile uint32_t millis;
 
 void main(void);


### PR DESCRIPTION
Major Change to the way dataItems are managed.  Now they are stored in arrays rather than individual variables and are indexed using constants.  This will make automatic CAN parsing easier when autogenerated code will be implemented later this year.  It also makes the idea of generalizing screen creation more simple.